### PR TITLE
Add WordPress-style plugin architecture with file-based config

### DIFF
--- a/app/bootstrap.php
+++ b/app/bootstrap.php
@@ -23,6 +23,7 @@ use Doctrine\ORM\ORMSetup;
 use Symfony\Component\Cache\Adapter\ArrayAdapter;
 use Symfony\Component\Cache\Adapter\FilesystemAdapter;
 use TheatreCMS\DI\ServiceRegistrar;
+use TheatreCMS\Plugin\PluginManager;
 use TheatreCMS\Repositories\UserRepository;
 use TheatreCMS\Theme\HookManager;
 
@@ -66,6 +67,9 @@ $container->set(EntityManager::class, static function (Container $c): EntityMana
 });
 
 ServiceRegistrar::register($container);
+
+// Plugin register phase (Phase 1): plugins register DI services before the Slim App is created.
+$container->get(PluginManager::class)->registerAll($container);
 
 // Add the Auth
 $container->get(UserRepository::class)->setAuth($container->get(Auth::class));

--- a/app/hooks.php
+++ b/app/hooks.php
@@ -53,11 +53,13 @@ if (!function_exists('do_action')) {
     /**
      * Fire all callbacks registered for an action tag.
      *
+     * Each handler receives $args directly; return values are discarded.
+     *
      * @param string $tag
      * @param mixed  ...$args
      */
     function do_action(string $tag, mixed ...$args): void
     {
-        HookManager::getInstance()->applyFilters($tag, null, ...$args);
+        HookManager::getInstance()->doAction($tag, ...$args);
     }
 }

--- a/app/hooks.php
+++ b/app/hooks.php
@@ -30,3 +30,34 @@ if (!function_exists('apply_filters')) {
         return HookManager::getInstance()->applyFilters($tag, $value, ...$args);
     }
 }
+
+if (!function_exists('add_action')) {
+    /**
+     * Register a callback to fire when an action tag is triggered.
+     *
+     * Actions are side-effect callbacks — unlike filters they do not transform
+     * a value.  Internally they share the same HookManager storage as filters;
+     * the return value is simply discarded when do_action() is called.
+     *
+     * @param string   $tag
+     * @param callable $callback
+     * @param int      $priority
+     */
+    function add_action(string $tag, callable $callback, int $priority = 10): void
+    {
+        HookManager::getInstance()->addFilter($tag, $callback, $priority);
+    }
+}
+
+if (!function_exists('do_action')) {
+    /**
+     * Fire all callbacks registered for an action tag.
+     *
+     * @param string $tag
+     * @param mixed  ...$args
+     */
+    function do_action(string $tag, mixed ...$args): void
+    {
+        HookManager::getInstance()->applyFilters($tag, null, ...$args);
+    }
+}

--- a/app/settings.php
+++ b/app/settings.php
@@ -82,6 +82,14 @@ return [
 
             // The active theme to use. Should correspond to a subdirectory in the themes dir.
             'active' => 'avlt'
+        ],
+
+        'plugins' => [
+            // Directory where plugins are stored. Each plugin in its own subdirectory.
+            'dir' => APP_ROOT . '/plugins',
+
+            // JSON file listing active plugin slugs (source of truth — not the database).
+            'config' => APP_ROOT . '/config/plugins.json',
         ]
     ]
 ];

--- a/config/plugins.json
+++ b/config/plugins.json
@@ -1,0 +1,5 @@
+{
+    "active": [
+        "example"
+    ]
+}

--- a/config/plugins.json
+++ b/config/plugins.json
@@ -1,5 +1,3 @@
 {
-    "active": [
-        "example"
-    ]
+    "active": []
 }

--- a/plugins/example/Plugin.php
+++ b/plugins/example/Plugin.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TheatreCMS\Plugin\Example;
+
+use DI\Container;
+use Psr\Http\Message\ResponseInterface as Response;
+use Psr\Http\Message\ServerRequestInterface as Request;
+use Slim\App;
+use TheatreCMS\Plugin\AbstractPlugin;
+
+/**
+ * Example plugin demonstrating the three TheatreCMS extension points:
+ *   1. DI service registration (register phase)
+ *   2. Route registration (boot phase)
+ *   3. Hook callbacks — filters and actions (boot phase)
+ */
+class Plugin extends AbstractPlugin
+{
+    public function getSlug(): string
+    {
+        return 'example';
+    }
+
+    /**
+     * Phase 1 — register a greeting service with the DI container.
+     */
+    public function register(Container $container): void
+    {
+        $container->set(GreetingService::class, static fn() => new GreetingService('TheatreCMS'));
+    }
+
+    /**
+     * Phase 2 — add a public route, a filter, and an action.
+     */
+    public function boot(App $app): void
+    {
+        $container = $app->getContainer();
+
+        $app->get('/example/hello', function (Request $request, Response $response) use ($container): Response {
+            /** @var GreetingService $greeter */
+            $greeter = $container->get(GreetingService::class);
+            $response->getBody()->write($greeter->greet());
+            return $response->withHeader('Content-Type', 'text/plain');
+        });
+
+        // Filter example: append a note to any page_title value passed through apply_filters()
+        add_filter('page_title', fn(string $title): string => $title . ' — Powered by TheatreCMS');
+
+        // Action example: runs whenever do_action('season_saved', $season) is called in core
+        add_action('season_saved', function (mixed $season): void {
+            // Plugins would do real work here (send notifications, invalidate caches, etc.)
+            error_log('[ExamplePlugin] season_saved action fired');
+        });
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Supporting class — kept in the same file for simplicity.
+// Larger plugins would split this into separate files and require_once them
+// at the top of Plugin.php before the namespace declaration.
+// ---------------------------------------------------------------------------
+
+class GreetingService
+{
+    public function __construct(private readonly string $name)
+    {
+    }
+
+    public function greet(): string
+    {
+        return "Hello from {$this->name}!";
+    }
+}

--- a/plugins/example/Plugin.php
+++ b/plugins/example/Plugin.php
@@ -48,7 +48,8 @@ class Plugin extends AbstractPlugin
         // Filter example: append a note to any page_title value passed through apply_filters()
         add_filter('page_title', fn(string $title): string => $title . ' — Powered by TheatreCMS');
 
-        // Action example: runs whenever do_action('season_saved', $season) is called in core
+        // Action example: runs whenever do_action('season_saved', $season) is called in core.
+        // do_action() passes args directly, so $season is the first argument.
         add_action('season_saved', function (mixed $season): void {
             // Plugins would do real work here (send notifications, invalidate caches, etc.)
             error_log('[ExamplePlugin] season_saved action fired');
@@ -59,7 +60,7 @@ class Plugin extends AbstractPlugin
 // ---------------------------------------------------------------------------
 // Supporting class — kept in the same file for simplicity.
 // Larger plugins would split this into separate files and require_once them
-// at the top of Plugin.php before the namespace declaration.
+// after the namespace declaration (namespace must come first in PHP).
 // ---------------------------------------------------------------------------
 
 class GreetingService

--- a/plugins/example/plugin.json
+++ b/plugins/example/plugin.json
@@ -1,0 +1,8 @@
+{
+    "name": "Example Plugin",
+    "slug": "example",
+    "version": "1.0.0",
+    "description": "A reference plugin demonstrating all TheatreCMS extension points.",
+    "author": "TheatreCMS Team",
+    "requires": "1.0.0"
+}

--- a/src/DI/ServiceRegistrar.php
+++ b/src/DI/ServiceRegistrar.php
@@ -30,6 +30,7 @@ use TheatreCMS\Repositories\SponsorRepository;
 use TheatreCMS\Repositories\UserRepository;
 use TheatreCMS\Repositories\VenueRepository;
 use TheatreCMS\Repositories\WorkRepository;
+use TheatreCMS\Plugin\PluginManager;
 use TheatreCMS\Text\EditorJsHtmlConverter;
 use TheatreCMS\Theme\HookManager;
 use TheatreCMS\Theme\ThemeManager;
@@ -58,6 +59,14 @@ class ServiceRegistrar
      */
     public static function registerSharedServices(Container $container): void
     {
+        $container->set(PluginManager::class, static function (ContainerInterface $c): PluginManager {
+            $settings = $c->get('settings');
+            return new PluginManager(
+                $settings['plugins']['dir']    ?? APP_ROOT . '/plugins',
+                $settings['plugins']['config'] ?? APP_ROOT . '/config/plugins.json',
+            );
+        });
+
         $container->set(HookManager::class, static fn(): HookManager => new HookManager());
 
         $container->set(ThemeManager::class, static function (ContainerInterface $c): ThemeManager {

--- a/src/Plugin/AbstractPlugin.php
+++ b/src/Plugin/AbstractPlugin.php
@@ -1,0 +1,38 @@
+<?php
+
+/**
+ *
+ * Copyright (C) 2026  TheatreCMS Team (https://theatrecms.dev)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ */
+
+namespace TheatreCMS\Plugin;
+
+use DI\Container;
+use Slim\App;
+
+abstract class AbstractPlugin implements PluginInterface
+{
+    /**
+     * Default no-op register. Override only if the plugin needs DI services.
+     */
+    public function register(Container $container): void
+    {
+    }
+
+    /**
+     * Default no-op boot. Override only if the plugin needs routes or middleware.
+     */
+    public function boot(App $app): void
+    {
+    }
+}

--- a/src/Plugin/PluginInterface.php
+++ b/src/Plugin/PluginInterface.php
@@ -1,0 +1,46 @@
+<?php
+
+/**
+ *
+ * Copyright (C) 2026  TheatreCMS Team (https://theatrecms.dev)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ */
+
+namespace TheatreCMS\Plugin;
+
+use DI\Container;
+use Slim\App;
+
+interface PluginInterface
+{
+    /**
+     * Returns the plugin slug — must match the plugin's directory name
+     * and the slug field in plugin.json.
+     */
+    public function getSlug(): string;
+
+    /**
+     * Phase 1 — DI registration.
+     *
+     * Called after the core container is built, before the Slim App is created.
+     * Register services, repositories, and controllers here.
+     */
+    public function register(Container $container): void;
+
+    /**
+     * Phase 2 — Application boot.
+     *
+     * Called after the Slim App is created and all core routes are loaded.
+     * Register routes, middleware, and hook callbacks here.
+     */
+    public function boot(App $app): void;
+}

--- a/src/Plugin/PluginManager.php
+++ b/src/Plugin/PluginManager.php
@@ -45,14 +45,18 @@ class PluginManager
 
         $data = json_decode((string) file_get_contents($this->configFile), true);
 
-        return is_array($data['active'] ?? null) ? $data['active'] : [];
+        if (!is_array($data) || !isset($data['active']) || !is_array($data['active'])) {
+            return [];
+        }
+
+        return array_values(array_filter($data['active'], 'is_string'));
     }
 
     /**
      * Phase 1 — instantiate every active plugin and call register().
      *
-     * Missing or invalid plugins emit E_USER_WARNING and are skipped so that
-     * one broken plugin does not prevent the application from booting.
+     * Missing, invalid, or throwing plugins emit E_USER_WARNING and are skipped
+     * so that one broken plugin does not prevent the application from booting.
      */
     public function registerAll(Container $container): void
     {
@@ -61,8 +65,15 @@ class PluginManager
             if ($plugin === null) {
                 continue;
             }
-            $this->loaded[$slug] = $plugin;
-            $plugin->register($container);
+            try {
+                $plugin->register($container);
+                $this->loaded[$slug] = $plugin;
+            } catch (\Throwable $e) {
+                trigger_error(
+                    "Plugin '$slug' threw during register(): " . $e->getMessage(),
+                    E_USER_WARNING
+                );
+            }
         }
     }
 
@@ -73,18 +84,29 @@ class PluginManager
      */
     public function bootAll(App $app): void
     {
-        foreach ($this->loaded as $plugin) {
-            $plugin->boot($app);
+        foreach ($this->loaded as $slug => $plugin) {
+            try {
+                $plugin->boot($app);
+            } catch (\Throwable $e) {
+                trigger_error(
+                    "Plugin '$slug' threw during boot(): " . $e->getMessage(),
+                    E_USER_WARNING
+                );
+            }
         }
     }
 
     /**
      * Adds a slug to the active list and persists the config file.
      *
-     * @throws RuntimeException if the plugin's Plugin.php is missing.
+     * @throws RuntimeException if the plugin's Plugin.php is missing or the slug is invalid.
      */
     public function activate(string $slug): void
     {
+        if (!$this->isValidSlug($slug)) {
+            throw new RuntimeException("Plugin slug '$slug' contains invalid characters (allowed: a-z, 0-9, -).");
+        }
+
         $pluginFile = $this->pluginsDir . '/' . $slug . '/Plugin.php';
         if (!file_exists($pluginFile)) {
             throw new RuntimeException("Plugin '$slug' not found at $pluginFile");
@@ -109,7 +131,7 @@ class PluginManager
     }
 
     /**
-     * Returns metadata from plugin.json for a given slug, or [] if absent.
+     * Returns metadata from plugin.json for a given slug, or [] if absent or invalid.
      *
      * @return array<string, string>
      */
@@ -120,7 +142,9 @@ class PluginManager
             return [];
         }
 
-        return json_decode((string) file_get_contents($metaFile), true) ?? [];
+        $decoded = json_decode((string) file_get_contents($metaFile), true);
+
+        return is_array($decoded) ? $decoded : [];
     }
 
     /**
@@ -148,6 +172,14 @@ class PluginManager
 
     private function loadPlugin(string $slug): ?PluginInterface
     {
+        if (!$this->isValidSlug($slug)) {
+            trigger_error(
+                "Plugin slug '$slug' contains invalid characters; skipping.",
+                E_USER_WARNING
+            );
+            return null;
+        }
+
         $pluginFile = $this->pluginsDir . '/' . $slug . '/Plugin.php';
 
         if (!file_exists($pluginFile)) {
@@ -158,13 +190,28 @@ class PluginManager
             return null;
         }
 
-        require_once $pluginFile;
+        // Guard against path traversal: ensure the resolved path stays inside pluginsDir.
+        $realPluginFile = realpath($pluginFile);
+        $realPluginsDir = realpath($this->pluginsDir);
+        if (
+            $realPluginFile === false ||
+            $realPluginsDir === false ||
+            !str_starts_with($realPluginFile, $realPluginsDir . DIRECTORY_SEPARATOR)
+        ) {
+            trigger_error(
+                "Plugin '$slug': resolved path is outside the plugins directory; skipping.",
+                E_USER_WARNING
+            );
+            return null;
+        }
+
+        require_once $realPluginFile;
 
         $class = $this->resolveClass($slug);
 
         if (!class_exists($class)) {
             trigger_error(
-                "Plugin class '$class' not found after requiring '$pluginFile'.",
+                "Plugin class '$class' not found after requiring '$realPluginFile'.",
                 E_USER_WARNING
             );
             return null;
@@ -180,13 +227,33 @@ class PluginManager
             return null;
         }
 
+        // Enforce that the plugin self-reports a slug matching its directory name.
+        if ($plugin->getSlug() !== $slug) {
+            trigger_error(
+                "Plugin class '$class' reports slug '{$plugin->getSlug()}' but was loaded from directory '$slug'; skipping.",
+                E_USER_WARNING
+            );
+            return null;
+        }
+
         return $plugin;
     }
 
-    /** Converts slug "example" → "TheatreCMS\Plugin\Example\Plugin" */
+    /**
+     * Converts a slug to the StudlyCase namespace segment used by the plugin class.
+     * e.g. "my-plugin" → "TheatreCMS\Plugin\MyPlugin\Plugin"
+     *      "box_office" → "TheatreCMS\Plugin\BoxOffice\Plugin"
+     */
     private function resolveClass(string $slug): string
     {
-        return 'TheatreCMS\\Plugin\\' . ucfirst($slug) . '\\Plugin';
+        $studly = implode('', array_map('ucfirst', preg_split('/[-_]+/', $slug) ?: [$slug]));
+        return 'TheatreCMS\\Plugin\\' . $studly . '\\Plugin';
+    }
+
+    /** Slugs must be lowercase alphanumeric with optional hyphens. */
+    private function isValidSlug(string $slug): bool
+    {
+        return (bool) preg_match('/^[a-z0-9][a-z0-9-]*$/', $slug);
     }
 
     /** @param string[] $active */

--- a/src/Plugin/PluginManager.php
+++ b/src/Plugin/PluginManager.php
@@ -1,0 +1,208 @@
+<?php
+
+/**
+ *
+ * Copyright (C) 2026  TheatreCMS Team (https://theatrecms.dev)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ */
+
+namespace TheatreCMS\Plugin;
+
+use DI\Container;
+use RuntimeException;
+use Slim\App;
+
+class PluginManager
+{
+    /** @var PluginInterface[] Indexed by slug */
+    private array $loaded = [];
+
+    public function __construct(
+        private readonly string $pluginsDir,
+        private readonly string $configFile,
+    ) {
+    }
+
+    /**
+     * Returns the active plugin slugs from the JSON config file.
+     *
+     * @return string[]
+     */
+    public function getActiveSlugs(): array
+    {
+        if (!file_exists($this->configFile)) {
+            return [];
+        }
+
+        $data = json_decode((string) file_get_contents($this->configFile), true);
+
+        return is_array($data['active'] ?? null) ? $data['active'] : [];
+    }
+
+    /**
+     * Phase 1 — instantiate every active plugin and call register().
+     *
+     * Missing or invalid plugins emit E_USER_WARNING and are skipped so that
+     * one broken plugin does not prevent the application from booting.
+     */
+    public function registerAll(Container $container): void
+    {
+        foreach ($this->getActiveSlugs() as $slug) {
+            $plugin = $this->loadPlugin($slug);
+            if ($plugin === null) {
+                continue;
+            }
+            $this->loaded[$slug] = $plugin;
+            $plugin->register($container);
+        }
+    }
+
+    /**
+     * Phase 2 — call boot() on every already-registered plugin.
+     *
+     * Must be called after registerAll() and after the Slim App is created.
+     */
+    public function bootAll(App $app): void
+    {
+        foreach ($this->loaded as $plugin) {
+            $plugin->boot($app);
+        }
+    }
+
+    /**
+     * Adds a slug to the active list and persists the config file.
+     *
+     * @throws RuntimeException if the plugin's Plugin.php is missing.
+     */
+    public function activate(string $slug): void
+    {
+        $pluginFile = $this->pluginsDir . '/' . $slug . '/Plugin.php';
+        if (!file_exists($pluginFile)) {
+            throw new RuntimeException("Plugin '$slug' not found at $pluginFile");
+        }
+
+        $active = $this->getActiveSlugs();
+        if (!in_array($slug, $active, true)) {
+            $active[] = $slug;
+            $this->writeConfig($active);
+        }
+    }
+
+    /**
+     * Removes a slug from the active list and persists the config file.
+     */
+    public function deactivate(string $slug): void
+    {
+        $active = array_values(
+            array_filter($this->getActiveSlugs(), fn(string $s) => $s !== $slug)
+        );
+        $this->writeConfig($active);
+    }
+
+    /**
+     * Returns metadata from plugin.json for a given slug, or [] if absent.
+     *
+     * @return array<string, string>
+     */
+    public function getMetadata(string $slug): array
+    {
+        $metaFile = $this->pluginsDir . '/' . $slug . '/plugin.json';
+        if (!file_exists($metaFile)) {
+            return [];
+        }
+
+        return json_decode((string) file_get_contents($metaFile), true) ?? [];
+    }
+
+    /**
+     * Scans the plugins directory and returns metadata for every installed plugin,
+     * regardless of active state. Keyed by slug.
+     *
+     * @return array<string, array<string, string>>
+     */
+    public function discoverAll(): array
+    {
+        $plugins = [];
+        $files = glob($this->pluginsDir . '/*/Plugin.php') ?: [];
+
+        foreach ($files as $pluginFile) {
+            $slug = basename(dirname($pluginFile));
+            $plugins[$slug] = $this->getMetadata($slug);
+        }
+
+        return $plugins;
+    }
+
+    // -------------------------------------------------------------------------
+    // Internals
+    // -------------------------------------------------------------------------
+
+    private function loadPlugin(string $slug): ?PluginInterface
+    {
+        $pluginFile = $this->pluginsDir . '/' . $slug . '/Plugin.php';
+
+        if (!file_exists($pluginFile)) {
+            trigger_error(
+                "Plugin '$slug' listed in plugins.json but '$pluginFile' was not found.",
+                E_USER_WARNING
+            );
+            return null;
+        }
+
+        require_once $pluginFile;
+
+        $class = $this->resolveClass($slug);
+
+        if (!class_exists($class)) {
+            trigger_error(
+                "Plugin class '$class' not found after requiring '$pluginFile'.",
+                E_USER_WARNING
+            );
+            return null;
+        }
+
+        $plugin = new $class();
+
+        if (!$plugin instanceof PluginInterface) {
+            trigger_error(
+                "Plugin class '$class' does not implement PluginInterface.",
+                E_USER_WARNING
+            );
+            return null;
+        }
+
+        return $plugin;
+    }
+
+    /** Converts slug "example" → "TheatreCMS\Plugin\Example\Plugin" */
+    private function resolveClass(string $slug): string
+    {
+        return 'TheatreCMS\\Plugin\\' . ucfirst($slug) . '\\Plugin';
+    }
+
+    /** @param string[] $active */
+    private function writeConfig(array $active): void
+    {
+        $dir = dirname($this->configFile);
+        if (!is_dir($dir)) {
+            mkdir($dir, 0755, true);
+        }
+
+        file_put_contents(
+            $this->configFile,
+            json_encode(
+                ['active' => array_values($active)],
+                JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES
+            ) . "\n"
+        );
+    }
+}

--- a/src/Theme/HookManager.php
+++ b/src/Theme/HookManager.php
@@ -60,4 +60,26 @@ class HookManager
 
         return $value;
     }
+
+    /**
+     * Fire all callbacks registered for an action tag.
+     *
+     * Unlike applyFilters(), return values are discarded and each handler
+     * receives the original $args directly (no value chaining).
+     */
+    public function doAction(string $tag, mixed ...$args): void
+    {
+        if (!isset($this->filters[$tag])) {
+            return;
+        }
+
+        $callbacks = $this->filters[$tag];
+        ksort($callbacks);
+
+        foreach ($callbacks as $handlers) {
+            foreach ($handlers as $handler) {
+                $handler(...$args);
+            }
+        }
+    }
 }

--- a/tests/Unit/Plugin/PluginManagerTest.php
+++ b/tests/Unit/Plugin/PluginManagerTest.php
@@ -1,0 +1,236 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TheatreCMS\Tests\Unit\Plugin;
+
+use PHPUnit\Framework\TestCase;
+use RuntimeException;
+use TheatreCMS\Plugin\PluginManager;
+
+class PluginManagerTest extends TestCase
+{
+    private string $tmpDir;
+    private string $pluginsDir;
+    private string $configFile;
+    private PluginManager $manager;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->tmpDir    = sys_get_temp_dir() . '/theatrecms_plugin_test_' . uniqid();
+        $this->pluginsDir = $this->tmpDir . '/plugins';
+        $this->configFile = $this->tmpDir . '/plugins.json';
+
+        mkdir($this->pluginsDir, 0755, true);
+
+        $this->manager = new PluginManager($this->pluginsDir, $this->configFile);
+    }
+
+    protected function tearDown(): void
+    {
+        $this->removeDirectory($this->tmpDir);
+        parent::tearDown();
+    }
+
+    // -------------------------------------------------------------------------
+    // getActiveSlugs()
+    // -------------------------------------------------------------------------
+
+    public function testGetActiveSlugsReturnEmptyArrayWhenConfigFileMissing(): void
+    {
+        self::assertSame([], $this->manager->getActiveSlugs());
+    }
+
+    public function testGetActiveSlugsReturnEmptyArrayForEmptyActiveList(): void
+    {
+        $this->writeConfig(['active' => []]);
+        self::assertSame([], $this->manager->getActiveSlugs());
+    }
+
+    public function testGetActiveSlugsReturnsSlugs(): void
+    {
+        $this->writeConfig(['active' => ['foo', 'bar']]);
+        self::assertSame(['foo', 'bar'], $this->manager->getActiveSlugs());
+    }
+
+    public function testGetActiveSlugsReturnEmptyArrayForInvalidJson(): void
+    {
+        file_put_contents($this->configFile, 'not-json{{{');
+        self::assertSame([], $this->manager->getActiveSlugs());
+    }
+
+    public function testGetActiveSlugsReturnEmptyArrayWhenActiveKeyMissing(): void
+    {
+        $this->writeConfig(['other' => 'value']);
+        self::assertSame([], $this->manager->getActiveSlugs());
+    }
+
+    public function testGetActiveSlugsReturnEmptyArrayWhenActiveIsNotAnArray(): void
+    {
+        $this->writeConfig(['active' => 'single-string']);
+        self::assertSame([], $this->manager->getActiveSlugs());
+    }
+
+    // -------------------------------------------------------------------------
+    // activate()
+    // -------------------------------------------------------------------------
+
+    public function testActivateAddsSlugToConfig(): void
+    {
+        $this->createDummyPlugin('my-plugin');
+
+        $this->manager->activate('my-plugin');
+
+        self::assertSame(['my-plugin'], $this->manager->getActiveSlugs());
+    }
+
+    public function testActivateIsIdempotent(): void
+    {
+        $this->createDummyPlugin('my-plugin');
+        $this->writeConfig(['active' => ['my-plugin']]);
+
+        $this->manager->activate('my-plugin');
+
+        self::assertSame(['my-plugin'], $this->manager->getActiveSlugs());
+    }
+
+    public function testActivateThrowsForMissingPluginDirectory(): void
+    {
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessageMatches('/not found/');
+
+        $this->manager->activate('nonexistent');
+    }
+
+    public function testActivateThrowsForInvalidSlug(): void
+    {
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessageMatches('/invalid characters/');
+
+        $this->manager->activate('../evil');
+    }
+
+    public function testActivateCreatesConfigDirectoryIfMissing(): void
+    {
+        $nestedConfig = $this->tmpDir . '/nested/dir/plugins.json';
+        $manager = new PluginManager($this->pluginsDir, $nestedConfig);
+        $this->createDummyPlugin('my-plugin');
+
+        $manager->activate('my-plugin');
+
+        self::assertFileExists($nestedConfig);
+    }
+
+    // -------------------------------------------------------------------------
+    // deactivate()
+    // -------------------------------------------------------------------------
+
+    public function testDeactivateRemovesSlugFromConfig(): void
+    {
+        $this->writeConfig(['active' => ['foo', 'bar']]);
+
+        $this->manager->deactivate('foo');
+
+        self::assertSame(['bar'], $this->manager->getActiveSlugs());
+    }
+
+    public function testDeactivateIsIdempotentForAbsentSlug(): void
+    {
+        $this->writeConfig(['active' => ['bar']]);
+
+        $this->manager->deactivate('nonexistent');
+
+        self::assertSame(['bar'], $this->manager->getActiveSlugs());
+    }
+
+    // -------------------------------------------------------------------------
+    // Missing-plugin graceful handling
+    // -------------------------------------------------------------------------
+
+    public function testRegisterAllSkipsMissingPlugin(): void
+    {
+        $this->writeConfig(['active' => ['missing-plugin']]);
+
+        $this->expectWarning();
+        $this->expectWarningMessageMatches('/not found/');
+
+        // Should not throw; the warning is emitted and the plugin is skipped.
+        $this->manager->registerAll($this->createMock(\DI\Container::class));
+    }
+
+    // -------------------------------------------------------------------------
+    // discoverAll()
+    // -------------------------------------------------------------------------
+
+    public function testDiscoverAllReturnsInstalledPlugins(): void
+    {
+        $this->createDummyPlugin('alpha');
+        $this->createDummyPlugin('beta');
+
+        $discovered = $this->manager->discoverAll();
+
+        self::assertArrayHasKey('alpha', $discovered);
+        self::assertArrayHasKey('beta', $discovered);
+    }
+
+    public function testDiscoverAllReturnsEmptyArrayWhenNoneInstalled(): void
+    {
+        self::assertSame([], $this->manager->discoverAll());
+    }
+
+    // -------------------------------------------------------------------------
+    // getMetadata()
+    // -------------------------------------------------------------------------
+
+    public function testGetMetadataReturnsEmptyArrayWhenJsonFileMissing(): void
+    {
+        self::assertSame([], $this->manager->getMetadata('no-such-plugin'));
+    }
+
+    public function testGetMetadataReturnsParsedJson(): void
+    {
+        $this->createDummyPlugin('my-plugin', ['name' => 'My Plugin', 'version' => '1.0.0']);
+
+        $meta = $this->manager->getMetadata('my-plugin');
+
+        self::assertSame('My Plugin', $meta['name']);
+        self::assertSame('1.0.0', $meta['version']);
+    }
+
+    // -------------------------------------------------------------------------
+    // Helpers
+    // -------------------------------------------------------------------------
+
+    private function writeConfig(array $data): void
+    {
+        file_put_contents($this->configFile, json_encode($data, JSON_PRETTY_PRINT));
+    }
+
+    private function createDummyPlugin(string $slug, array $meta = []): void
+    {
+        $dir = $this->pluginsDir . '/' . $slug;
+        mkdir($dir, 0755, true);
+        // Minimal Plugin.php so file_exists() passes for activate()
+        file_put_contents($dir . '/Plugin.php', '<?php // dummy');
+        if ($meta !== []) {
+            file_put_contents($dir . '/plugin.json', json_encode($meta));
+        }
+    }
+
+    private function removeDirectory(string $dir): void
+    {
+        if (!is_dir($dir)) {
+            return;
+        }
+        foreach (scandir($dir) as $item) {
+            if ($item === '.' || $item === '..') {
+                continue;
+            }
+            $path = $dir . '/' . $item;
+            is_dir($path) ? $this->removeDirectory($path) : unlink($path);
+        }
+        rmdir($dir);
+    }
+}

--- a/www/index.php
+++ b/www/index.php
@@ -55,9 +55,6 @@ require ROUTES_DIR . '/admin/pages.php';
 require ROUTES_DIR . '/admin/images.php';
 require ROUTES_DIR . '/frontend/seasons.php';
 
-// Plugin boot phase (Phase 2): plugins register routes, middleware, and hook callbacks.
-$container->get(PluginManager::class)->bootAll($app);
-
 $app->get('/admin/login', [LoginController::class, 'login']);
 $app->post('/admin/login', [LoginController::class, 'authenticate']);
 $app->get('/admin/logout', [LoginController::class, 'logout']);
@@ -75,4 +72,9 @@ $app->get('/', function (Request $request, Response $response) use ($container) 
 
     return $twig->render($response, 'index.html.twig', ['posts' => $posts]);
 });
+
+// Plugin boot phase (Phase 2): plugins register routes, middleware, and hook callbacks.
+// Runs after ALL core routes so plugins see the full routing table.
+$container->get(PluginManager::class)->bootAll($app);
+
 $app->run();

--- a/www/index.php
+++ b/www/index.php
@@ -21,6 +21,7 @@ require_once ROOT_DIR . "/vendor/autoload.php";
 
 use TheatreCMS\Controllers\LoginController;
 use TheatreCMS\Middleware\RequireTwigMiddleware;
+use TheatreCMS\Plugin\PluginManager;
 use TheatreCMS\Repositories\PostRepository;
 use TheatreCMS\Theme\TemplateResolver;
 use Psr\Http\Message\ResponseInterface as Response;
@@ -53,6 +54,9 @@ require ROUTES_DIR . '/admin/posts.php';
 require ROUTES_DIR . '/admin/pages.php';
 require ROUTES_DIR . '/admin/images.php';
 require ROUTES_DIR . '/frontend/seasons.php';
+
+// Plugin boot phase (Phase 2): plugins register routes, middleware, and hook callbacks.
+$container->get(PluginManager::class)->bootAll($app);
 
 $app->get('/admin/login', [LoginController::class, 'login']);
 $app->post('/admin/login', [LoginController::class, 'authenticate']);


### PR DESCRIPTION
## Summary

- Introduces a WordPress-style plugin architecture where active plugin state is stored in `config/plugins.json` (not the database), mirroring how the active theme is configured in `app/settings.php`
- Two-phase loading: `registerAll()` (DI services, before Slim App) in `bootstrap.php`; `bootAll()` (routes, middleware, hooks) in `index.php` after core routes
- Adds `add_action()` / `do_action()` global helpers alongside the existing `add_filter()` / `apply_filters()` — all backed by the same `HookManager`

## New Files

| File | Purpose |
|------|---------|
| `src/Plugin/PluginInterface.php` | Contract: `getSlug()`, `register(Container)`, `boot(App)` |
| `src/Plugin/AbstractPlugin.php` | No-op base class — plugins override only what they need |
| `src/Plugin/PluginManager.php` | Loads active plugins from JSON, drives both phases, exposes `activate()`/`deactivate()` |
| `config/plugins.json` | Source of truth for active plugin slugs |
| `plugins/example/Plugin.php` | Reference plugin showing DI registration, a route, a filter, and an action |
| `plugins/example/plugin.json` | Plugin metadata (name, version, description, author) |

## Modified Files

- `app/settings.php` — added `settings.plugins.dir` and `settings.plugins.config`
- `app/hooks.php` — added `add_action()` and `do_action()`
- `src/DI/ServiceRegistrar.php` — registers `PluginManager` as a shared service
- `app/bootstrap.php` — calls `PluginManager::registerAll()` (Phase 1)
- `www/index.php` — calls `PluginManager::bootAll()` (Phase 2)

## Plugin Structure Convention

```
plugins/
  my-plugin/
    plugin.json      # metadata
    Plugin.php       # class TheatreCMS\Plugin\MyPlugin\Plugin extends AbstractPlugin
```

Activating/deactivating a plugin rewrites `config/plugins.json`. A missing plugin emits `E_USER_WARNING` and is skipped — one bad plugin cannot crash the site.

## Test plan

- [ ] `GET /example/hello` returns `Hello from TheatreCMS!` when `example` is in `config/plugins.json`
- [ ] Removing `example` from the active array causes the route to 404
- [ ] `PluginManager::activate('example')` adds the slug and persists the JSON file
- [ ] `PluginManager::deactivate('example')` removes the slug and persists the JSON file
- [ ] `PluginManager::activate('nonexistent')` throws `RuntimeException`
- [ ] A slug listed in `plugins.json` with no matching directory emits `E_USER_WARNING` and does not crash the app
- [ ] Add unit tests in `tests/Unit/Plugin/PluginManagerTest.php`

https://claude.ai/code/session_01B8vr5fJjG1evbZ7n7UGpT7

---
_Generated by [Claude Code](https://claude.ai/code/session_01B8vr5fJjG1evbZ7n7UGpT7)_