### PR TITLE
Implement quick-create modal for production entities and routes

### DIFF
--- a/app/routes/admin/people.php
+++ b/app/routes/admin/people.php
@@ -9,12 +9,14 @@ use TheatreCMS\Middleware\RequireTwigMiddleware;
 
 if (isset($app)) {
     $app->group('/admin/people', function ($group) {
-        $group->post('/create',   [PersonController::class, 'store']);
-        $group->get('/create',    [PersonController::class, 'create']);
-        $group->post('/edit',     [PersonController::class, 'update']);
-        $group->get('/edit/{id}', [PersonController::class, 'edit']);
-        $group->delete('/{id}',   [PersonController::class, 'destroy']);
-        $group->get('',           [PersonController::class, 'index']);
+        $group->post('/create',        [PersonController::class, 'store']);
+        $group->get('/create',         [PersonController::class, 'create']);
+        $group->post('/quick-create',  [PersonController::class, 'quickStore']);
+        $group->get('/quick-create',   [PersonController::class, 'quickCreate']);
+        $group->post('/edit',          [PersonController::class, 'update']);
+        $group->get('/edit/{id}',      [PersonController::class, 'edit']);
+        $group->delete('/{id}',        [PersonController::class, 'destroy']);
+        $group->get('',                [PersonController::class, 'index']);
     })->add(new RequireTwigMiddleware($container))
       ->add(new RequireCapabilityMiddleware($container->get(AuthorizationService::class), Capability::MANAGE_PEOPLE))
       ->add($container->get(AuthMiddleware::class));

--- a/app/routes/admin/sponsors.php
+++ b/app/routes/admin/sponsors.php
@@ -9,13 +9,15 @@ use TheatreCMS\Middleware\RequireTwigMiddleware;
 
 if (isset($app)) {
     $app->group('/admin/sponsors', function ($group) {
-        $group->post('/create',   [SponsorController::class, 'store']);
-        $group->get('/create',    [SponsorController::class, 'create']);
-        $group->post('/edit',     [SponsorController::class, 'update']);
-        $group->get('/edit/{id}', [SponsorController::class, 'edit']);
-        $group->delete('/{id}/logo', [SponsorController::class, 'removeLogo']);
-        $group->delete('/{id}',   [SponsorController::class, 'destroy']);
-        $group->get('',           [SponsorController::class, 'index']);
+        $group->post('/create',        [SponsorController::class, 'store']);
+        $group->get('/create',         [SponsorController::class, 'create']);
+        $group->post('/quick-create',  [SponsorController::class, 'quickStore']);
+        $group->get('/quick-create',   [SponsorController::class, 'quickCreate']);
+        $group->post('/edit',          [SponsorController::class, 'update']);
+        $group->get('/edit/{id}',      [SponsorController::class, 'edit']);
+        $group->delete('/{id}/logo',   [SponsorController::class, 'removeLogo']);
+        $group->delete('/{id}',        [SponsorController::class, 'destroy']);
+        $group->get('',                [SponsorController::class, 'index']);
     })->add(new RequireTwigMiddleware($container))
       ->add(new RequireCapabilityMiddleware($container->get(AuthorizationService::class), Capability::MANAGE_PRODUCTIONS))
       ->add($container->get(AuthMiddleware::class));

--- a/app/routes/admin/venues.php
+++ b/app/routes/admin/venues.php
@@ -9,12 +9,14 @@ use TheatreCMS\Middleware\RequireTwigMiddleware;
 
 if (isset($app)) {
     $app->group('/admin/venues', function ($group) {
-        $group->post('/create',   [VenueController::class, 'store']);
-        $group->get('/create',    [VenueController::class, 'create']);
-        $group->post('/edit',     [VenueController::class, 'update']);
-        $group->get('/edit/{id}', [VenueController::class, 'edit']);
-        $group->delete('/{id}',   [VenueController::class, 'destroy']);
-        $group->get('',           [VenueController::class, 'index']);
+        $group->post('/create',        [VenueController::class, 'store']);
+        $group->get('/create',         [VenueController::class, 'create']);
+        $group->post('/quick-create',  [VenueController::class, 'quickStore']);
+        $group->get('/quick-create',   [VenueController::class, 'quickCreate']);
+        $group->post('/edit',          [VenueController::class, 'update']);
+        $group->get('/edit/{id}',      [VenueController::class, 'edit']);
+        $group->delete('/{id}',        [VenueController::class, 'destroy']);
+        $group->get('',                [VenueController::class, 'index']);
     })->add(new RequireTwigMiddleware($container))
       ->add(new RequireCapabilityMiddleware($container->get(AuthorizationService::class), Capability::MANAGE_PRODUCTIONS))
       ->add($container->get(AuthMiddleware::class));

--- a/app/routes/admin/works.php
+++ b/app/routes/admin/works.php
@@ -9,12 +9,14 @@ use TheatreCMS\Middleware\RequireTwigMiddleware;
 
 if (isset($app)) {
     $app->group('/admin/works', function ($group) {
-        $group->post('/create', [WorksController::class, 'store']);
-        $group->get('/create', [WorksController::class, 'create']);
-        $group->post('/edit', [WorksController::class, 'update']);
-        $group->get('/edit/{id}', [WorksController::class, 'edit']);
-        $group->delete('/{id}', [WorksController::class, 'destroy']);
-        $group->get('', [WorksController::class, 'index']);
+        $group->post('/create',        [WorksController::class, 'store']);
+        $group->get('/create',         [WorksController::class, 'create']);
+        $group->post('/quick-create',  [WorksController::class, 'quickStore']);
+        $group->get('/quick-create',   [WorksController::class, 'quickCreate']);
+        $group->post('/edit',          [WorksController::class, 'update']);
+        $group->get('/edit/{id}',      [WorksController::class, 'edit']);
+        $group->delete('/{id}',        [WorksController::class, 'destroy']);
+        $group->get('',                [WorksController::class, 'index']);
     })->add(new RequireTwigMiddleware($container))
       ->add(new RequireCapabilityMiddleware($container->get(AuthorizationService::class), Capability::MANAGE_PEOPLE))
       ->add($container->get(AuthMiddleware::class));

--- a/src/Controllers/PersonController.php
+++ b/src/Controllers/PersonController.php
@@ -85,6 +85,45 @@ class PersonController extends BaseController
         return $response->withHeader('Location', '/admin/people');
     }
 
+    public function quickCreate(Request $request, Response $response, array $args = []): Response
+    {
+        return $this->twig->render($response, 'admin/people/_quick_create_modal.html.twig');
+    }
+
+    public function quickStore(Request $request, Response $response, array $args = []): Response
+    {
+        $data = $request->getParsedBody();
+
+        if (empty($data)) {
+            return $this->twig->render($response, 'admin/partials/_alert.html.twig', [
+                'type'    => 'error',
+                'message' => 'Unable to create person. Please check your input.',
+            ]);
+        }
+
+        $data = $this->parseArgs($data, [
+            'firstName' => null,
+            'lastName'  => null,
+        ]);
+
+        $person = $this->repository->create($data);
+
+        $trigger = json_encode([
+            'entityCreated' => [
+                'id'   => $person->getId(),
+                'name' => $person->getName(),
+                'type' => 'person',
+            ],
+        ]);
+
+        $response = $this->twig->render($response, 'admin/partials/_alert.html.twig', [
+            'type'    => 'success',
+            'message' => $person->getName() . ' was added.',
+        ]);
+
+        return $response->withHeader('HX-Trigger', $trigger);
+    }
+
     public function update(Request $request, Response $response, array $args = []): Response
     {
         $data = $request->getParsedBody();

--- a/src/Controllers/ProductionController.php
+++ b/src/Controllers/ProductionController.php
@@ -166,10 +166,43 @@ class ProductionController extends BaseController
         $data = $this->parseArgs($data, [
             'sponsorshipSponsorIds' => [],
             'venueId' => null,
+            'creativeIds' => [],
+            'creativeRoles' => [],
+            'performerIds' => [],
+            'performerRoles' => [],
         ]);
 
         $production = $this->repository->create($data);
         $this->handleFeaturedImageUpload($request, $production);
+
+        $personRepository = $this->entityManager->getRepository(Person::class);
+
+        $attachPeople = function (array $ids, array $roles, callable $add) use ($personRepository) {
+            foreach ($ids as $idx => $personId) {
+                if (empty($personId)) {
+                    continue;
+                }
+
+                $person = $personRepository->find($personId);
+                if (!$person) {
+                    continue;
+                }
+
+                $add($person, $roles[$idx] ?? null);
+            }
+        };
+
+        $attachPeople(
+            is_array($data['creativeIds']) ? $data['creativeIds'] : [],
+            is_array($data['creativeRoles']) ? $data['creativeRoles'] : [],
+            fn (Person $person, ?string $role) => $production->addToCreativeTeam($person, $role)
+        );
+
+        $attachPeople(
+            is_array($data['performerIds']) ? $data['performerIds'] : [],
+            is_array($data['performerRoles']) ? $data['performerRoles'] : [],
+            fn (Person $person, ?string $role) => $production->addPerformer($person, $role)
+        );
 
         $this->syncSponsorships($production, $data['sponsorshipSponsorIds']);
         $this->entityManager->flush();

--- a/src/Controllers/SponsorController.php
+++ b/src/Controllers/SponsorController.php
@@ -119,6 +119,45 @@ class SponsorController extends BaseController
         return $response->withHeader('Location', '/admin/sponsors');
     }
 
+    public function quickCreate(Request $request, Response $response, array $args = []): Response
+    {
+        return $this->twig->render($response, 'admin/sponsors/_quick_create_modal.html.twig');
+    }
+
+    public function quickStore(Request $request, Response $response, array $args = []): Response
+    {
+        $data = $request->getParsedBody();
+        $name = trim($data['name'] ?? '');
+
+        if (empty($name)) {
+            return $this->twig->render($response, 'admin/partials/_alert.html.twig', [
+                'type'    => 'error',
+                'message' => 'A name is required to create a sponsor.',
+            ]);
+        }
+
+        $sponsor = $this->sponsorRepository->create([
+            'name'       => $name,
+            'websiteUrl' => trim($data['websiteUrl'] ?? '') ?: null,
+            'logoUrl'    => null,
+        ]);
+
+        $trigger = json_encode([
+            'entityCreated' => [
+                'id'   => $sponsor->getId(),
+                'name' => $sponsor->getName(),
+                'type' => 'sponsor',
+            ],
+        ]);
+
+        $response = $this->twig->render($response, 'admin/partials/_alert.html.twig', [
+            'type'    => 'success',
+            'message' => $sponsor->getName() . ' was added.',
+        ]);
+
+        return $response->withHeader('HX-Trigger', $trigger);
+    }
+
     public function update(Request $request, Response $response, array $args = []): Response
     {
         $data = $request->getParsedBody();

--- a/src/Controllers/VenueController.php
+++ b/src/Controllers/VenueController.php
@@ -93,6 +93,48 @@ class VenueController extends BaseController
         return $response->withHeader('Location', '/admin/venues');
     }
 
+    public function quickCreate(Request $request, Response $response, array $args = []): Response
+    {
+        return $this->twig->render($response, 'admin/venues/_quick_create_modal.html.twig');
+    }
+
+    public function quickStore(Request $request, Response $response, array $args = []): Response
+    {
+        $data = $request->getParsedBody();
+
+        if (empty($data)) {
+            return $this->twig->render($response, 'admin/partials/_alert.html.twig', [
+                'type'    => 'error',
+                'message' => 'Unable to create venue. Please check your input.',
+            ]);
+        }
+
+        $data = $this->parseArgs($data, [
+            'name'     => null,
+            'address'  => null,
+            'city'     => null,
+            'state'    => null,
+            'postcode' => null,
+        ]);
+
+        $venue = $this->repository->create($data);
+
+        $trigger = json_encode([
+            'entityCreated' => [
+                'id'   => $venue->getId(),
+                'name' => $venue->getName(),
+                'type' => 'venue',
+            ],
+        ]);
+
+        $response = $this->twig->render($response, 'admin/partials/_alert.html.twig', [
+            'type'    => 'success',
+            'message' => $venue->getName() . ' was added.',
+        ]);
+
+        return $response->withHeader('HX-Trigger', $trigger);
+    }
+
     public function update(Request $request, Response $response, array $args = []): Response
     {
         $data = $request->getParsedBody();

--- a/src/Controllers/WorksController.php
+++ b/src/Controllers/WorksController.php
@@ -88,6 +88,59 @@ class WorksController extends BaseController
         return $response->withHeader('Location', '/admin/works');
     }
 
+    public function quickCreate(Request $request, Response $response, array $args = []): Response
+    {
+        return $this->twig->render($response, 'admin/works/_quick_create_modal.html.twig', [
+            'people' => $this->personRepo->fetchAll(),
+        ]);
+    }
+
+    public function quickStore(Request $request, Response $response, array $args = []): Response
+    {
+        $data = $request->getParsedBody();
+        $title = trim($data['title'] ?? '');
+
+        if (empty($title)) {
+            return $this->twig->render($response, 'admin/partials/_alert.html.twig', [
+                'type'    => 'error',
+                'message' => 'A title is required to create a work.',
+            ]);
+        }
+
+        $workData = ['title' => $title];
+        $creatorId = intval($data['creatorId'] ?? 0);
+        if ($creatorId > 0) {
+            $workData['creators'] = [[
+                'id'   => $creatorId,
+                'role' => trim($data['creatorRole'] ?? ''),
+            ]];
+        }
+
+        $work = $this->repository->create($workData);
+
+        if (!$work instanceof Work) {
+            return $this->twig->render($response, 'admin/partials/_alert.html.twig', [
+                'type'    => 'error',
+                'message' => 'Unable to create work. Please try again.',
+            ]);
+        }
+
+        $trigger = json_encode([
+            'entityCreated' => [
+                'id'   => $work->getId(),
+                'name' => $work->getTitle(),
+                'type' => 'work',
+            ],
+        ]);
+
+        $response = $this->twig->render($response, 'admin/partials/_alert.html.twig', [
+            'type'    => 'success',
+            'message' => '"' . $work->getTitle() . '" was added.',
+        ]);
+
+        return $response->withHeader('HX-Trigger', $trigger);
+    }
+
     public function update(Request $request, Response $response, array $args = []): Response
     {
         $data = $request->getParsedBody();

--- a/src/Models/Person.php
+++ b/src/Models/Person.php
@@ -70,13 +70,13 @@ class Person extends ModelBase implements JsonSerializable
         return $this;
     }
 
-    public function setBiography(string $biography): self
+    public function setBiography(?string $biography): self
     {
         $this->biography = $biography;
         return $this;
     }
 
-    public function setHeadshotUrl(string $headshotUrl): self
+    public function setHeadshotUrl(?string $headshotUrl): self
     {
         $this->headshotUrl = $headshotUrl;
         return $this;

--- a/src/Models/Sponsor.php
+++ b/src/Models/Sponsor.php
@@ -21,10 +21,10 @@ class Sponsor extends ModelBase
     private string $name;
 
     #[Column(name: 'logo_url', type: 'string', nullable: true)]
-    private string $logoUrl;
+    private ?string $logoUrl = null;
 
     #[Column(name: 'website_url', type: 'string', nullable: true)]
-    private string $websiteUrl;
+    private ?string $websiteUrl = null;
 
     #[OneToMany(mappedBy: 'sponsor', targetEntity: Sponsorship::class)]
     private Collection $sponsorships;
@@ -51,24 +51,24 @@ class Sponsor extends ModelBase
         return $this;
     }
 
-    public function getLogoUrl(): string
+    public function getLogoUrl(): ?string
     {
         return $this->logoUrl;
     }
 
-    public function setLogoUrl(string $logoUrl): self
+    public function setLogoUrl(?string $logoUrl): self
     {
         $this->logoUrl = $logoUrl;
 
         return $this;
     }
 
-    public function getWebsiteUrl(): string
+    public function getWebsiteUrl(): ?string
     {
         return $this->websiteUrl;
     }
 
-    public function setWebsiteUrl(string $websiteUrl): self
+    public function setWebsiteUrl(?string $websiteUrl): self
     {
         $this->websiteUrl = $websiteUrl;
 

--- a/templates/admin/people/_quick_create_modal.html.twig
+++ b/templates/admin/people/_quick_create_modal.html.twig
@@ -1,0 +1,42 @@
+<div class="flex items-center justify-between px-6 py-4 border-b border-gray-200">
+	<h2 class="text-lg font-semibold text-gray-900">Add New Person</h2>
+	<button type="button" onclick="document.getElementById('quick-create-modal').close()" class="text-gray-400 hover:text-gray-600 focus:outline-none" aria-label="Close">
+		<svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="18" y1="6" x2="6" y2="18"/><line x1="6" y1="6" x2="18" y2="18"/></svg>
+	</button>
+</div>
+
+<div id="modal-flash" class="px-6 pt-4"></div>
+
+<form id="quick-create-form"
+      hx-post="/admin/people/quick-create"
+      hx-target="#modal-flash"
+      hx-swap="innerHTML"
+      class="px-6 pb-6 space-y-4">
+	<div class="grid grid-cols-2 gap-4">
+		<div>
+			<label for="qc-firstName" class="block text-sm font-medium text-gray-700 mb-1">First Name <span class="text-red-500">*</span></label>
+			<input type="text" name="firstName" id="qc-firstName" required
+			       class="w-full rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500"
+			       placeholder="e.g. Jane">
+		</div>
+		<div>
+			<label for="qc-lastName" class="block text-sm font-medium text-gray-700 mb-1">Last Name <span class="text-red-500">*</span></label>
+			<input type="text" name="lastName" id="qc-lastName" required
+			       class="w-full rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500"
+			       placeholder="e.g. Doe">
+		</div>
+	</div>
+
+	<p class="text-xs text-gray-500">Full details (biography, headshot, etc.) can be added later from the People section.</p>
+
+	<div class="flex justify-end gap-3 pt-2 border-t border-gray-100">
+		<button type="button" onclick="document.getElementById('quick-create-modal').close()"
+		        class="px-4 py-2 text-sm font-medium text-gray-700 bg-white border border-gray-300 rounded-md hover:bg-gray-50">
+			Cancel
+		</button>
+		<button type="submit"
+		        class="px-4 py-2 text-sm font-medium text-white bg-blue-600 rounded-md hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500">
+			Add Person
+		</button>
+	</div>
+</form>

--- a/templates/admin/productions/_quick_create_modal.html.twig
+++ b/templates/admin/productions/_quick_create_modal.html.twig
@@ -1,0 +1,8 @@
+{# ── Quick-create modal ───────────────────────────────────────────────────── #}
+<dialog id="quick-create-modal"
+        class="rounded-lg shadow-xl p-0 w-full max-w-lg open:flex open:flex-col backdrop:bg-black/50"
+        aria-modal="true">
+	<div id="quick-create-modal-content" class="w-full">
+		{# Populated by HTMX hx-get on the + New … buttons #}
+	</div>
+</dialog>

--- a/templates/admin/productions/create.html.twig
+++ b/templates/admin/productions/create.html.twig
@@ -38,48 +38,6 @@
 		</div>
 	{% endif %}
 
-	{% if works is empty %}
-		<div class="mb-4 rounded-md bg-yellow-50 p-4 border border-yellow-200">
-			<div class="flex">
-				<div
-					class="flex-shrink-0">
-					<!-- exclamation icon -->
-					<svg class="h-5 w-5 text-yellow-600" xmlns="http://www.w3.org/2000/svg" viewbox="0 0 20 20" fill="currentColor" aria-hidden="true">
-						<path fill-rule="evenodd" d="M8.257 3.099c.765-1.36 2.681-1.36 3.446 0l5.516 9.8A1.75 1.75 0 0 1 16.016 16H3.984A1.75 1.75 0 0 1 2.74 12.899l5.517-9.8zM11 13a1 1 0 1 1-2 0 1 1 0 0 1 2 0zm-1-8a.75.75 0 0 0-.75.75v4.5a.75.75 0 0 0 1.5 0v-4.5A.75.75 0 0 0 10 5z" clip-rule="evenodd"/>
-					</svg>
-				</div>
-				<div class="ml-3">
-					<h3 class="text-sm font-medium text-yellow-800">No works available</h3>
-					<div class="mt-1 text-sm text-yellow-700">
-						There are no works in the system to attach to this production. You can add works from the Works
-						                        section before creating a production.
-					</div>
-				</div>
-			</div>
-		</div>
-	{% endif %}
-
-	{% if people is empty %}
-		<div class="mb-4 rounded-md bg-yellow-50 p-4 border border-yellow-200">
-			<div class="flex">
-				<div
-					class="flex-shrink-0">
-					<!-- exclamation icon -->
-					<svg class="h-5 w-5 text-yellow-600" xmlns="http://www.w3.org/2000/svg" viewbox="0 0 20 20" fill="currentColor" aria-hidden="true">
-						<path fill-rule="evenodd" d="M8.257 3.099c.765-1.36 2.681-1.36 3.446 0l5.516 9.8A1.75 1.75 0 0 1 16.016 16H3.984A1.75 1.75 0 0 1 2.74 12.899l5.517-9.8zM11 13a1 1 0 1 1-2 0 1 1 0 0 1 2 0zm-1-8a.75.75 0 0 0-.75.75v4.5a.75.75 0 0 0 1.5 0v-4.5A.75.75 0 0 0 10 5z" clip-rule="evenodd"/>
-					</svg>
-				</div>
-				<div class="ml-3">
-					<h3 class="text-sm font-medium text-yellow-800">No people available</h3>
-					<div class="mt-1 text-sm text-yellow-700">
-						There are no people in the system to attach to this production. You can add people from the People
-						                        section before creating a production.
-					</div>
-				</div>
-			</div>
-		</div>
-	{% endif %}
-
 	<form action="/{{ base_path|default('') }}admin/productions/create" method="POST" enctype="multipart/form-data" class="space-y-6" hx-post="/{{ base_path|default('') }}admin/productions/create" hx-target="#flash-messages" hx-swap="innerHTML" hx-trigger="htmxSubmit">
 		<div class="grid grid-cols-1 md:grid-cols-2 gap-6">
 			<div class="md:col-span-2">
@@ -108,21 +66,6 @@
 			</div>
 
 			<div class="md:col-span-2">
-				<label for="venueId" class="block text-sm font-medium text-gray-700 mb-1">Performance Venue</label>
-				<p class="text-xs text-gray-500 mb-2">Optional. Leave this blank if your organization only uses one performance space or if you do not need venue-level tracking.</p>
-				{% if venues is empty %}
-					<div class="text-xs text-gray-500 mt-1">No venues yet. You can still create this production and assign a venue later if needed.</div>
-				{% else %}
-					<select name="venueId" id="venueId" class="searchable-select w-full rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500">
-						<option value="">Select a venue</option>
-						{% for v in venues %}
-							<option value="{{ v.id }}">{{ v.name }}</option>
-						{% endfor %}
-					</select>
-				{% endif %}
-			</div>
-
-			<div class="md:col-span-2">
 				<fieldset class="grid grid-cols-1 md:grid-cols-2 gap-6">
 					<div>
 						<label for="opening" class="block text-sm font-medium text-gray-700 mb-1">Opening
@@ -137,6 +80,22 @@
 						<input type="date" name="closing" id="closing" required class="w-full rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500">
 					</div>
 				</fieldset>
+			</div>
+
+			<div id="featured-image-section" class="md:col-span-2">
+				<label for="poster" class="block text-sm font-medium text-gray-700 mb-1">Featured Image</label>
+				<div class="rounded-md border border-gray-200 bg-gray-50 p-4">
+					<p id="current-featured-image-placeholder" class="text-sm text-gray-500">No featured image set.</p>
+					<img
+						id="upload-featured-image-preview"
+						src=""
+						alt="Selected featured image preview"
+						class="mt-3 hidden max-h-40 w-auto object-contain"
+					>
+				</div>
+
+				<input type="file" name="poster" id="poster" accept="image/*" class="mt-3 w-full rounded-md border-gray-300 shadow-sm">
+				<p class="mt-1 text-xs text-gray-500">Uploading a file will set the featured image when saved.</p>
 			</div>
 
 			<div class="md:col-span-2 space-y-3">
@@ -161,70 +120,221 @@
 				<input type="url" name="ticketPurchaseUrl" id="ticketPurchaseUrl" class="w-full rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500" placeholder="https://example.com/tickets">
 			</div>
 
-			<div class="md:col-span-2">
-				<label for="works" class="block text-sm font-medium text-gray-700 mb-1">Works</label>
-				<select multiple="multiple" name="works[]" id="works" class="w-full rounded-md border-gray-300 shadow-sm">
-					{% for w in works %}
-						<option value="{{ w.id }}">{{ w.title }}</option>
-					{% endfor %}
-				</select>
-			</div>
+			<div class="md:col-span-2 space-y-4 p-6 border border-dashed border-gray-200 rounded-lg bg-gray-50">
+				<div class="flex items-start justify-between gap-4">
+					<div>
+						<h2 class="text-lg font-semibold text-gray-900 mb-1">Works</h2>
+						<p class="text-sm text-gray-600">Choose which works are part of this production.</p>
+					</div>
+					<div class="flex items-center gap-2">
+						<button type="button"
+						        class="inline-flex items-center gap-1 px-2 py-1 text-xs font-medium text-blue-700 bg-blue-50 border border-blue-200 rounded hover:bg-blue-100"
+						        hx-get="/admin/works/quick-create"
+						        hx-target="#quick-create-modal-content"
+						        hx-swap="innerHTML">
+							+ New Work
+						</button>
+						<button type="button" id="add-work" class="px-4 py-2 text-sm font-medium text-white bg-blue-600 rounded-md shadow-sm hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500">
+							Add Work
+						</button>
+					</div>
+				</div>
 
-			<div class="md:col-span-2 relative overflow-x-auto bg-neutral-primary-soft shadow-xs rounded-base border border-default">
-				{% if people is empty %}
-					<div class="mb-4 rounded-md bg-yellow-50 p-4 border border-yellow-200">
-						<div class="flex">
-							<div
-								class="flex-shrink-0">
-								<!-- exclamation icon -->
-								<svg class="h-5 w-5 text-yellow-600" xmlns="http://www.w3.org/2000/svg" viewbox="0 0 20 20" fill="currentColor" aria-hidden="true">
-									<path fill-rule="evenodd" d="M8.257 3.099c.765-1.36 2.681-1.36 3.446 0l5.516 9.8A1.75 1.75 0 0 1 16.016 16H3.984A1.75 1.75 0 0 1 2.74 12.899l5.517-9.8zM11 13a1 1 0 1 1-2 0 1 1 0 0 1 2 0zm-1-8a.75.75 0 0 0-.75.75v4.5a.75.75 0 0 0 1.5 0v-4.5A.75.75 0 0 0 10 5z" clip-rule="evenodd"/>
+				{% if works is empty %}
+					<div class="rounded-md bg-blue-50 p-4 border border-blue-200">
+						<div class="flex gap-3">
+							<div class="flex-shrink-0">
+								<svg class="h-5 w-5 text-blue-500" xmlns="http://www.w3.org/2000/svg" viewbox="0 0 20 20" fill="currentColor" aria-hidden="true">
+									<path fill-rule="evenodd" d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-7-4a1 1 0 11-2 0 1 1 0 012 0zM9 9a1 1 0 000 2v3a1 1 0 001 1h1a1 1 0 100-2v-3a1 1 0 00-1-1H9z" clip-rule="evenodd"/>
 								</svg>
 							</div>
 							<div class="ml-3">
-								<h3 class="text-sm font-medium text-yellow-800">No people available</h3>
-								<div class="mt-1 text-sm text-yellow-700">
-									There are no people in the system to add to the creative team. Add people from the
-									                                    People section before assigning creatives.
-								</div>
+								<h3 class="text-sm font-medium text-blue-800">No works available</h3>
+								<div class="mt-1 text-sm text-blue-700">There are no works in the system yet. This is not required to create a production — you can add works now or later.</div>
 							</div>
 						</div>
 					</div>
 				{% endif %}
-				<table class="w-full text-sm text-left rtl:text-right text-body">
-					<thead class="text-sm text-body bg-neutral-secondary-medium border-b border-default-medium">
-						<tr>
-							<th scope="col" class="px-6 py-3 font-medium">
-								Creative Team
-							</th>
-							<th scope="col" class="px-6 py-3 font-medium">
-								Role
-							</th>
-							<th>
-								<button type="button" id="add-creative">Add Creative</button>
-							</th>
-						</tr>
-					</thead>
-					<tbody>
-						<tr class="bg-neutral-primary-soft border-b  border-default">
-							<th scope="row" class="px-6 py-4 font-medium text-heading whitespace-nowrap">
-								<select aria-label="Person" class="searchable-select w-full rounded-md border-gray-300 shadow-sm" name="creatives[][personId]">
-									<option value="">Select a person</option>
-									{% for p in people %}
-										<option value="{{ p.id }}">{{ p.name }}</option>
-									{% endfor %}
-								</select>
-							</th>
-							<td class="px-6 py-4">
-								<label class="sr-only" for="creatives[][role]">Role</label>
-								<input class="w-full rounded-md border-gray-300 shadow-sm" type="text" id="creatives[][role]" name="creatives[][role]" placeholder="e.g. Director">
-							</td>
-							<td class="px-6 py-4 text-right">
-								<a href="#" class="font-medium text-fg-brand hover:underline">Delete</a>
-							</td>
-						</tr>
-					</tbody>
-				</table>
+
+				<div class="relative overflow-x-auto bg-white border border-gray-200 shadow-sm rounded-md">
+					<table class="w-full text-sm text-left text-gray-700">
+						<thead class="bg-gray-50 text-xs uppercase tracking-wide text-gray-500 border-b border-gray-200">
+							<tr>
+								<th class="px-4 py-3 font-medium">Work</th>
+								<th class="px-4 py-3 font-medium text-right">Action</th>
+							</tr>
+						</thead>
+						<tbody data-work-rows>
+							<tr class="hidden bg-white border-b border-gray-100" data-work-template>
+								<th scope="row" class="px-4 py-3 font-medium text-gray-900">
+									<select aria-label="Work" class="searchable-select w-full rounded-md border-gray-300 shadow-sm" name="works[]">
+										<option value="">Select a work</option>
+										{% for w in works %}
+											<option value="{{ w.id }}">{{ w.title }}</option>
+										{% endfor %}
+									</select>
+								</th>
+								<td class="px-4 py-3 text-right">
+									<a href="#" class="delete-work font-medium text-blue-600 hover:underline">Delete</a>
+								</td>
+							</tr>
+						</tbody>
+					</table>
+				</div>
+			</div>
+
+			<div class="md:col-span-2 space-y-4 p-6 border border-dashed border-gray-200 rounded-lg bg-gray-50">
+				<div class="flex items-start justify-between gap-4">
+					<div>
+						<h2 class="text-lg font-semibold text-gray-900 mb-1">Venue</h2>
+						<p class="text-sm text-gray-600">Optional. Leave this blank if your organization only uses one performance space or if you do not need venue-level tracking.</p>
+					</div>
+					<button type="button"
+					        class="inline-flex items-center gap-1 px-2 py-1 text-xs font-medium text-blue-700 bg-blue-50 border border-blue-200 rounded hover:bg-blue-100"
+					        hx-get="/admin/venues/quick-create"
+					        hx-target="#quick-create-modal-content"
+					        hx-swap="innerHTML">
+						+ New Venue
+					</button>
+				</div>
+
+				{% if venues is empty %}
+					<div id="venueId-empty-placeholder" class="rounded-md bg-blue-50 p-4 border border-blue-200">
+						<div class="flex gap-3">
+							<div class="flex-shrink-0">
+								<svg class="h-5 w-5 text-blue-500" xmlns="http://www.w3.org/2000/svg" viewbox="0 0 20 20" fill="currentColor" aria-hidden="true">
+									<path fill-rule="evenodd" d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-7-4a1 1 0 11-2 0 1 1 0 012 0zM9 9a1 1 0 000 2v3a1 1 0 001 1h1a1 1 0 100-2v-3a1 1 0 00-1-1H9z" clip-rule="evenodd"/>
+								</svg>
+							</div>
+							<div class="ml-3">
+								<h3 class="text-sm font-medium text-blue-800">No venues available</h3>
+								<div class="mt-1 text-sm text-blue-700">There are no venues in the system yet. This is not required to create a production — you can add a venue now or later.</div>
+							</div>
+						</div>
+					</div>
+				{% else %}
+					<div class="bg-white border border-gray-200 shadow-sm rounded-md p-4">
+						<select name="venueId" id="venueId" class="searchable-select w-full rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500">
+							<option value="">Select a venue</option>
+							{% for v in venues %}
+								<option value="{{ v.id }}">{{ v.name }}</option>
+							{% endfor %}
+						</select>
+					</div>
+				{% endif %}
+			</div>
+
+			<div class="md:col-span-2 space-y-6 p-6 border border-dashed border-gray-200 rounded-lg bg-gray-50">
+				<div class="flex items-start justify-between gap-4">
+					<div>
+						<h2 class="text-lg font-semibold text-gray-900 mb-1">People</h2>
+						<p class="text-sm text-gray-600">Add the creative team and performers for this production.</p>
+					</div>
+					<button type="button"
+					        class="inline-flex items-center gap-1 px-2 py-1 text-xs font-medium text-blue-700 bg-blue-50 border border-blue-200 rounded hover:bg-blue-100"
+					        onclick="document.body.dataset.qcPersonTarget = 'creative'"
+					        hx-get="/admin/people/quick-create"
+					        hx-target="#quick-create-modal-content"
+					        hx-swap="innerHTML">
+						+ New Person
+					</button>
+				</div>
+
+				{% if people is empty %}
+					<div class="rounded-md bg-blue-50 p-4 border border-blue-200">
+						<div class="flex gap-3">
+							<div class="flex-shrink-0">
+								<svg class="h-5 w-5 text-blue-500" xmlns="http://www.w3.org/2000/svg" viewbox="0 0 20 20" fill="currentColor" aria-hidden="true">
+									<path fill-rule="evenodd" d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-7-4a1 1 0 11-2 0 1 1 0 012 0zM9 9a1 1 0 000 2v3a1 1 0 001 1h1a1 1 0 100-2v-3a1 1 0 00-1-1H9z" clip-rule="evenodd"/>
+								</svg>
+							</div>
+							<div class="ml-3">
+								<h3 class="text-sm font-medium text-blue-800">No people available</h3>
+								<div class="mt-1 text-sm text-blue-700">There are no people in the system yet. This is not required to create a production — you can add people now or later.</div>
+							</div>
+						</div>
+					</div>
+				{% endif %}
+
+				<div class="space-y-3">
+					<div class="flex items-start justify-between gap-4">
+						<h3 class="text-sm font-semibold text-gray-800">Creative Team</h3>
+						<button type="button" id="add-creative" class="px-4 py-2 text-sm font-medium text-white bg-blue-600 rounded-md shadow-sm hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 {% if people is empty %}opacity-50 cursor-not-allowed{% endif %}" {% if people is empty %} disabled {% endif %}>
+							Add Creative
+						</button>
+					</div>
+
+					<div class="relative overflow-x-auto bg-white border border-gray-200 shadow-sm rounded-md">
+						<table class="w-full text-sm text-left text-gray-700">
+							<thead class="bg-gray-50 text-xs uppercase tracking-wide text-gray-500 border-b border-gray-200">
+								<tr>
+									<th class="px-4 py-3 font-medium">Person</th>
+									<th class="px-4 py-3 font-medium">Role</th>
+									<th class="px-4 py-3 font-medium text-right"></th>
+								</tr>
+							</thead>
+							<tbody data-creative-rows>
+								<tr class="hidden bg-white border-b border-gray-100" data-creative-template>
+									<th scope="row" class="px-4 py-3 font-medium text-gray-900">
+										<select aria-label="Person" class="searchable-select w-full rounded-md border-gray-300 shadow-sm" name="creativeIds[]">
+											<option value="">Select a person</option>
+											{% for p in people %}
+												<option value="{{ p.id }}">{{ p.name }}</option>
+											{% endfor %}
+										</select>
+									</th>
+									<td class="px-4 py-3">
+										<label class="sr-only" for="creative-role-template">Role</label>
+										<input class="w-full rounded-md border-gray-300 shadow-sm" type="text" id="creative-role-template" name="creativeRoles[]" placeholder="e.g. Director">
+									</td>
+									<td class="px-4 py-3 text-right">
+										<a href="#" class="delete-creative font-medium text-blue-600 hover:underline">Delete</a>
+									</td>
+								</tr>
+							</tbody>
+						</table>
+					</div>
+				</div>
+
+				<div class="space-y-3">
+					<div class="flex items-start justify-between gap-4">
+						<h3 class="text-sm font-semibold text-gray-800">Performers</h3>
+						<button type="button" id="add-performer" class="px-4 py-2 text-sm font-medium text-white bg-blue-600 rounded-md shadow-sm hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 {% if people is empty %}opacity-50 cursor-not-allowed{% endif %}" {% if people is empty %} disabled {% endif %}>
+							Add Performer
+						</button>
+					</div>
+
+					<div class="relative overflow-x-auto bg-white border border-gray-200 shadow-sm rounded-md">
+						<table class="w-full text-sm text-left text-gray-700">
+							<thead class="bg-gray-50 text-xs uppercase tracking-wide text-gray-500 border-b border-gray-200">
+								<tr>
+									<th class="px-4 py-3 font-medium">Person</th>
+									<th class="px-4 py-3 font-medium">Role</th>
+									<th class="px-4 py-3 font-medium text-right"></th>
+								</tr>
+							</thead>
+							<tbody data-performer-rows>
+								<tr class="hidden bg-white border-b border-gray-100" data-performer-template>
+									<th scope="row" class="px-4 py-3 font-medium text-gray-900">
+										<select aria-label="Person" class="searchable-select w-full rounded-md border-gray-300 shadow-sm" name="performerIds[]">
+											<option value="">Select a person</option>
+											{% for p in people %}
+												<option value="{{ p.id }}">{{ p.name }}</option>
+											{% endfor %}
+										</select>
+									</th>
+									<td class="px-4 py-3">
+										<label class="sr-only" for="performer-role-template">Role</label>
+										<input class="w-full rounded-md border-gray-300 shadow-sm" type="text" id="performer-role-template" name="performerRoles[]" placeholder="e.g. Hamlet">
+									</td>
+									<td class="px-4 py-3 text-right">
+										<a href="#" class="delete-performer font-medium text-blue-600 hover:underline">Delete</a>
+									</td>
+								</tr>
+							</tbody>
+						</table>
+					</div>
+				</div>
 			</div>
 
 			<div class="md:col-span-2 space-y-4 p-6 border border-dashed border-gray-200 rounded-lg bg-gray-50">
@@ -233,14 +343,33 @@
 						<h2 class="text-lg font-semibold text-gray-900 mb-1">Sponsorships</h2>
 						<p class="text-sm text-gray-600">Choose which sponsors support this production.</p>
 					</div>
-					<button type="button" id="add-sponsorship" class="px-4 py-2 text-sm font-medium text-white bg-blue-600 rounded-md shadow-sm hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 {% if sponsorsList is empty %}opacity-50 cursor-not-allowed{% endif %}" {% if sponsorsList is empty %} disabled {% endif %}>
-						Add Sponsorship
-					</button>
+					<div class="flex items-center gap-2">
+						<button type="button"
+						        class="inline-flex items-center gap-1 px-2 py-1 text-xs font-medium text-blue-700 bg-blue-50 border border-blue-200 rounded hover:bg-blue-100"
+						        hx-get="/admin/sponsors/quick-create"
+						        hx-target="#quick-create-modal-content"
+						        hx-swap="innerHTML">
+							+ New Sponsor
+						</button>
+						<button type="button" id="add-sponsorship" class="px-4 py-2 text-sm font-medium text-white bg-blue-600 rounded-md shadow-sm hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 {% if sponsorsList is empty %}opacity-50 cursor-not-allowed{% endif %}" {% if sponsorsList is empty %} disabled {% endif %}>
+							Add Sponsorship
+						</button>
+					</div>
 				</div>
 
 				{% if sponsorsList is empty %}
-					<div class="rounded-md bg-yellow-50 border border-yellow-200 p-4 text-sm text-yellow-800">
-						There are no sponsors yet. Add sponsors from the Sponsors section before assigning them here.
+					<div id="sponsorship-empty-placeholder" class="rounded-md bg-blue-50 p-4 border border-blue-200">
+						<div class="flex gap-3">
+							<div class="flex-shrink-0">
+								<svg class="h-5 w-5 text-blue-500" xmlns="http://www.w3.org/2000/svg" viewbox="0 0 20 20" fill="currentColor" aria-hidden="true">
+									<path fill-rule="evenodd" d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-7-4a1 1 0 11-2 0 1 1 0 012 0zM9 9a1 1 0 000 2v3a1 1 0 001 1h1a1 1 0 100-2v-3a1 1 0 00-1-1H9z" clip-rule="evenodd"/>
+								</svg>
+							</div>
+							<div class="ml-3">
+								<h3 class="text-sm font-medium text-blue-800">No sponsors available</h3>
+								<div class="mt-1 text-sm text-blue-700">There are no sponsors in the system yet. This is not required to create a production — you can add sponsors now or later.</div>
+							</div>
+						</div>
 					</div>
 				{% else %}
 					<div class="relative overflow-x-auto bg-white border border-gray-200 shadow-sm rounded-md">
@@ -283,22 +412,6 @@
 					</div>
 				{% endif %}
 			</div>
-
-			<div id="featured-image-section" class="md:col-span-2">
-				<label for="poster" class="block text-sm font-medium text-gray-700 mb-1">Featured Image</label>
-				<div class="rounded-md border border-gray-200 bg-gray-50 p-4">
-					<p id="current-featured-image-placeholder" class="text-sm text-gray-500">No featured image set.</p>
-					<img
-						id="upload-featured-image-preview"
-						src=""
-						alt="Selected featured image preview"
-						class="mt-3 hidden max-h-40 w-auto object-contain"
-					>
-				</div>
-
-				<input type="file" name="poster" id="poster" accept="image/*" class="mt-3 w-full rounded-md border-gray-300 shadow-sm">
-				<p class="mt-1 text-xs text-gray-500">Uploading a file will set the featured image when saved.</p>
-			</div>
 		</div>
 
 		<div class="flex items-center justify-end space-x-3 pt-4 border-t">
@@ -326,7 +439,8 @@ const uploadFeaturedImagePreview = document.getElementById('upload-featured-imag
 
 const editorData = null;
 
-const setupDynamicRows = (namespace) => {
+const setupDynamicRows = (namespace, options) => {
+const requireMinimumRow = !options || options.requireMinimumRow !== false;
 const rowsBody = document.querySelector (`tbody[data-${namespace}-rows]`);
 const templateRow = rowsBody ? rowsBody.querySelector (`tr[data-${namespace}-template]`) : null;
 const addButton = document.getElementById (`add-${namespace}`);
@@ -357,7 +471,7 @@ return;
 deleteLink.addEventListener('click', function (event) {
 event.preventDefault();
 const visibleRows = getVisibleRows();
-if (visibleRows.length<= 1) {
+if (requireMinimumRow && visibleRows.length<= 1) {
                             resetRowInputs(row);
                             return;
                         }
@@ -405,7 +519,9 @@ rowsBody.insertBefore(row, templateRow);
 }
 };
 
+if (requireMinimumRow) {
 ensureRowPresent();
+}
 
 if (addButton) {
 addButton.addEventListener('click', function (event) {
@@ -419,8 +535,9 @@ rowsBody.insertBefore(row, templateRow);
 }
 };
 
-setupDynamicRows('creative');
-setupDynamicRows('performer');
+setupDynamicRows('creative', {requireMinimumRow: false});
+setupDynamicRows('performer', {requireMinimumRow: false});
+setupDynamicRows('work', {requireMinimumRow: false});
 setupDynamicRows('sponsorship');
 
 if (posterInput && uploadFeaturedImagePreview) {
@@ -486,7 +603,14 @@ isSaving = false;
 });
 });
 
-form.addEventListener('htmx:afterRequest', function () {
+form.addEventListener('htmx:afterRequest', function (event) {
+// This listener is attached to the form to catch its own hx-post submission,
+// but htmx:afterRequest bubbles from any descendant — including the "+ New …"
+// quick-create buttons nested inside this form. Ignore those so quick-create
+// clicks don't yank the page down to #flash-messages.
+if (event.detail && event.detail.elt !== form) {
+return;
+}
 isSaving = false;
 document.getElementById('flash-messages') ?. scrollIntoView({behavior: 'smooth', block: 'nearest'});
 });
@@ -501,4 +625,23 @@ byUrl: '/admin/productions/images/fetch'
 }));
 });
 </script>
-		{% endblock %}
+<script type="module">
+	import {initQuickCreateHandlers, buildVenueFallback, buildSponsorshipTableFallback} from '/assets/js/production-quick-create.js';
+
+	initQuickCreateHandlers({
+		person: {
+			type: 'rowset-group',
+			contextAttr: 'qcPersonTarget',
+			candidates: [
+				{namespace: 'creative', selectName: 'creativeIds[]'},
+				{namespace: 'performer', selectName: 'performerIds[]'},
+			],
+		},
+		work: {type: 'rowset', namespace: 'work', selectName: 'works[]'},
+		venue: {type: 'single', selectName: 'venueId', buildFallback: buildVenueFallback},
+		sponsor: {type: 'rowset', namespace: 'sponsorship', selectName: 'sponsorshipSponsorIds[]', buildFallback: buildSponsorshipTableFallback},
+	});
+</script>
+
+{% include 'admin/productions/_quick_create_modal.html.twig' %}
+{% endblock %}

--- a/templates/admin/productions/edit.html.twig
+++ b/templates/admin/productions/edit.html.twig
@@ -84,19 +84,25 @@
 
 					{% if works is empty %}
 						<div class="md:col-span-2 rounded-md bg-yellow-50 p-4 border border-yellow-200">
-							<div class="flex">
-								<div class="flex-shrink-0">
-									<svg class="h-5 w-5 text-yellow-600" xmlns="http://www.w3.org/2000/svg" viewbox="0 0 20 20" fill="currentColor" aria-hidden="true">
-										<path fill-rule="evenodd" d="M8.257 3.099c.765-1.36 2.681-1.36 3.446 0l5.516 9.8A1.75 1.75 0 0 1 16.016 16H3.984A1.75 1.75 0 0 1 2.74 12.899l5.517-9.8zM11 13a1 1 0 1 1-2 0 1 1 0 0 1 2 0zm-1-8a.75.75 0 0 0-.75.75v4.5a.75.75 0 0 0 1.5 0v-4.5A.75.75 0 0 0 10 5z" clip-rule="evenodd"/>
-									</svg>
-								</div>
-								<div class="ml-3">
-									<h3 class="text-sm font-medium text-yellow-800">No works available</h3>
-									<div class="mt-1 text-sm text-yellow-700">
-										There are no works in the system to attach to this production. You can add works from the Works
-										                                        section before creating a production.
+							<div class="flex items-start justify-between gap-4">
+								<div class="flex gap-3">
+									<div class="flex-shrink-0">
+										<svg class="h-5 w-5 text-yellow-600" xmlns="http://www.w3.org/2000/svg" viewbox="0 0 20 20" fill="currentColor" aria-hidden="true">
+											<path fill-rule="evenodd" d="M8.257 3.099c.765-1.36 2.681-1.36 3.446 0l5.516 9.8A1.75 1.75 0 0 1 16.016 16H3.984A1.75 1.75 0 0 1 2.74 12.899l5.517-9.8zM11 13a1 1 0 1 1-2 0 1 1 0 0 1 2 0zm-1-8a.75.75 0 0 0-.75.75v4.5a.75.75 0 0 0 1.5 0v-4.5A.75.75 0 0 0 10 5z" clip-rule="evenodd"/>
+										</svg>
+									</div>
+									<div class="ml-3">
+										<h3 class="text-sm font-medium text-yellow-800">No works available</h3>
+										<div class="mt-1 text-sm text-yellow-700">There are no works in the system yet.</div>
 									</div>
 								</div>
+								<button type="button"
+								        class="flex-shrink-0 inline-flex items-center gap-1 px-3 py-1.5 text-xs font-medium text-yellow-800 bg-yellow-100 border border-yellow-300 rounded-md hover:bg-yellow-200"
+								        hx-get="/admin/works/quick-create"
+								        hx-target="#quick-create-modal-content"
+								        hx-swap="innerHTML">
+									+ Create First Work
+								</button>
 							</div>
 						</div>
 					{% endif %}
@@ -129,10 +135,19 @@
 					</div>
 
 					<div class="md:col-span-2">
-						<label for="venueId" class="block text-sm font-medium text-gray-700 mb-1">Performance Venue</label>
+						<div class="flex items-center justify-between mb-1">
+							<label for="venueId" class="block text-sm font-medium text-gray-700">Performance Venue</label>
+							<button type="button"
+							        class="inline-flex items-center gap-1 px-2 py-1 text-xs font-medium text-blue-700 bg-blue-50 border border-blue-200 rounded hover:bg-blue-100"
+							        hx-get="/admin/venues/quick-create"
+							        hx-target="#quick-create-modal-content"
+							        hx-swap="innerHTML">
+								+ New Venue
+							</button>
+						</div>
 						<p class="text-xs text-gray-500 mb-2">Optional. Leave this blank if your organization only uses one performance space or if you do not need venue-level tracking.</p>
 						{% if venues is empty %}
-							<div class="text-xs text-gray-500 mt-1">No venues available. You can keep this production without a venue and assign one later.</div>
+							<div id="venueId-empty-placeholder" class="text-xs text-gray-500 mt-1">No venues available. You can keep this production without a venue and assign one later.</div>
 						{% else %}
 							<select name="venueId" id="venueId" class="searchable-select w-full rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500">
 								<option value="">Select a venue</option>
@@ -186,7 +201,16 @@
 					</div>
 
 					<div class="md:col-span-2">
-						<label for="works" class="block text-sm font-medium text-gray-700 mb-1">Works</label>
+						<div class="flex items-center justify-between mb-1">
+							<label for="works" class="block text-sm font-medium text-gray-700">Works</label>
+							<button type="button"
+							        class="inline-flex items-center gap-1 px-2 py-1 text-xs font-medium text-blue-700 bg-blue-50 border border-blue-200 rounded hover:bg-blue-100"
+							        hx-get="/admin/works/quick-create"
+							        hx-target="#quick-create-modal-content"
+							        hx-swap="innerHTML">
+								+ New Work
+							</button>
+						</div>
 						<select multiple="multiple" name="works[]" id="works" class="w-full rounded-md border-gray-300 shadow-sm">
 							{% for w in works %}
 								<option value="{{ w.id }}" {% if w.id in selectedWorkIds %} selected {% endif %}>{{ w.title }}</option>
@@ -205,19 +229,26 @@
 
 				{% if people is empty %}
 					<div class="mb-4 rounded-md bg-yellow-50 p-4 border border-yellow-200">
-						<div class="flex">
-							<div class="flex-shrink-0">
-								<svg class="h-5 w-5 text-yellow-600" xmlns="http://www.w3.org/2000/svg" viewbox="0 0 20 20" fill="currentColor" aria-hidden="true">
-									<path fill-rule="evenodd" d="M8.257 3.099c.765-1.36 2.681-1.36 3.446 0l5.516 9.8A1.75 1.75 0 0 1 16.016 16H3.984A1.75 1.75 0 0 1 2.74 12.899l5.517-9.8zM11 13a1 1 0 1 1-2 0 1 1 0 0 1 2 0zm-1-8a.75.75 0 0 0-.75.75v4.5a.75.75 0 0 0 1.5 0v-4.5A.75.75 0 0 0 10 5z" clip-rule="evenodd"/>
-								</svg>
-							</div>
-							<div class="ml-3">
-								<h3 class="text-sm font-medium text-yellow-800">No people available</h3>
-								<div class="mt-1 text-sm text-yellow-700">
-									There are no people in the system. Add people from the People section before
-									                                    assigning creatives or performers.
+						<div class="flex items-start justify-between gap-4">
+							<div class="flex gap-3">
+								<div class="flex-shrink-0">
+									<svg class="h-5 w-5 text-yellow-600" xmlns="http://www.w3.org/2000/svg" viewbox="0 0 20 20" fill="currentColor" aria-hidden="true">
+										<path fill-rule="evenodd" d="M8.257 3.099c.765-1.36 2.681-1.36 3.446 0l5.516 9.8A1.75 1.75 0 0 1 16.016 16H3.984A1.75 1.75 0 0 1 2.74 12.899l5.517-9.8zM11 13a1 1 0 1 1-2 0 1 1 0 0 1 2 0zm-1-8a.75.75 0 0 0-.75.75v4.5a.75.75 0 0 0 1.5 0v-4.5A.75.75 0 0 0 10 5z" clip-rule="evenodd"/>
+									</svg>
+								</div>
+								<div class="ml-3">
+									<h3 class="text-sm font-medium text-yellow-800">No people available</h3>
+									<div class="mt-1 text-sm text-yellow-700">There are no people in the system yet.</div>
 								</div>
 							</div>
+							<button type="button"
+							        class="flex-shrink-0 inline-flex items-center gap-1 px-3 py-1.5 text-xs font-medium text-yellow-800 bg-yellow-100 border border-yellow-300 rounded-md hover:bg-yellow-200"
+							        onclick="document.body.dataset.qcPersonTarget = 'performer'"
+							        hx-get="/admin/people/quick-create"
+							        hx-target="#quick-create-modal-content"
+							        hx-swap="innerHTML">
+								+ Add First Person
+							</button>
 						</div>
 					</div>
 				{% endif %}
@@ -236,30 +267,22 @@
 										Role
 									</th>
 									<th>
-										<button type="button" id="add-performer">Add Performer</button>
+										<div class="flex items-center justify-end gap-2 px-2">
+											<button type="button"
+											        class="inline-flex items-center gap-1 px-2 py-1 text-xs font-medium text-blue-700 bg-blue-50 border border-blue-200 rounded hover:bg-blue-100"
+											        onclick="document.body.dataset.qcPersonTarget = 'performer'"
+											        hx-get="/admin/people/quick-create"
+											        hx-target="#quick-create-modal-content"
+											        hx-swap="innerHTML">
+												+ New Person
+											</button>
+											<button type="button" id="add-performer" class="inline-flex items-center gap-1 px-2 py-1 text-xs font-medium text-gray-700 bg-white border border-gray-300 rounded hover:bg-gray-50">Add Performer</button>
+										</div>
 									</th>
 								</tr>
 							</thead>
 							<tbody data-performer-rows>
-								{% if performers is empty %}
-									<tr class="bg-neutral-primary-soft border-b border-default" data-performer-row>
-										<th scope="row" class="px-6 py-4 font-medium text-heading whitespace-nowrap">
-											<select aria-label="Person" class="searchable-select w-full rounded-md border-gray-300 shadow-sm" name="performerIds[]">
-												<option value="">Select a person</option>
-												{% for p in people %}
-													<option value="{{ p.id }}">{{ p.name }}</option>
-												{% endfor %}
-											</select>
-										</th>
-										<td class="px-6 py-4">
-											<label class="sr-only" for="performer-role-empty">Role</label>
-											<input class="w-full rounded-md border-gray-300 shadow-sm" type="text" id="performer-role-empty" name="performerRoles[]" placeholder="e.g. Hamlet">
-										</td>
-										<td class="px-6 py-4 text-right">
-											<a href="#" class="delete-performer font-medium text-fg-brand hover:underline">Delete</a>
-										</td>
-									</tr>
-								{% else %}
+								{% if performers is not empty %}
 									{% for p in performers %}
 										<tr class="bg-neutral-primary-soft border-b border-default" data-performer-row>
 											<th scope="row" class="px-6 py-4 font-medium text-heading whitespace-nowrap">
@@ -315,7 +338,17 @@
 										Role
 									</th>
 									<th>
-										<button type="button" id="add-productionTeam">Add Member</button>
+										<div class="flex items-center justify-end gap-2 px-2">
+											<button type="button"
+											        class="inline-flex items-center gap-1 px-2 py-1 text-xs font-medium text-blue-700 bg-blue-50 border border-blue-200 rounded hover:bg-blue-100"
+											        onclick="document.body.dataset.qcPersonTarget = 'productionTeam'"
+											        hx-get="/admin/people/quick-create"
+											        hx-target="#quick-create-modal-content"
+											        hx-swap="innerHTML">
+												+ New Person
+											</button>
+											<button type="button" id="add-productionTeam" class="inline-flex items-center gap-1 px-2 py-1 text-xs font-medium text-gray-700 bg-white border border-gray-300 rounded hover:bg-gray-50">Add Member</button>
+										</div>
 									</th>
 								</tr>
 							</thead>
@@ -395,14 +428,23 @@
 							<h2 class="text-lg font-semibold text-gray-900 mb-1">Production Sponsorships</h2>
 							<p class="text-sm text-gray-600">Select sponsors that are attached to this production.</p>
 						</div>
-						<button type="button" id="add-sponsorship" class="px-4 py-2 text-sm font-medium text-white bg-blue-600 rounded-md shadow-sm hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 {% if sponsorsList is empty %}opacity-50 cursor-not-allowed{% endif %}" {% if sponsorsList is empty %} disabled {% endif %}>
-							Add Sponsorship
-						</button>
+						<div class="flex items-center gap-2">
+							<button type="button"
+							        class="inline-flex items-center gap-1 px-2 py-1 text-xs font-medium text-blue-700 bg-blue-50 border border-blue-200 rounded hover:bg-blue-100"
+							        hx-get="/admin/sponsors/quick-create"
+							        hx-target="#quick-create-modal-content"
+							        hx-swap="innerHTML">
+								+ New Sponsor
+							</button>
+							<button type="button" id="add-sponsorship" class="px-4 py-2 text-sm font-medium text-white bg-blue-600 rounded-md shadow-sm hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 {% if sponsorsList is empty %}opacity-50 cursor-not-allowed{% endif %}" {% if sponsorsList is empty %} disabled {% endif %}>
+								Add Sponsorship
+							</button>
+						</div>
 					</div>
 
 					{% if sponsorsList is empty %}
-						<div class="rounded-md bg-yellow-50 border border-yellow-200 p-4 text-sm text-yellow-800">
-							There are no sponsors yet. Add sponsors from the Sponsors section before assigning them here.
+						<div id="sponsorship-empty-placeholder" class="rounded-md bg-yellow-50 border border-yellow-200 p-4 text-sm text-yellow-800">
+							No sponsors yet. Use the <strong>+ New Sponsor</strong> button above to add one.
 						</div>
 					{% else %}
 						<div class="relative overflow-x-auto bg-white border border-gray-200 shadow-sm rounded-md">
@@ -520,7 +562,8 @@ const uploadFeaturedImagePreview = document.getElementById('upload-featured-imag
 
 const editorData = {{ editorDescription is not null ? editorDescription|raw : 'null' }};
 
-const setupDynamicRows = (namespace) => {
+const setupDynamicRows = (namespace, options) => {
+const requireMinimumRow = !options || options.requireMinimumRow !== false;
 const rowsBody = document.querySelector (`tbody[data-${namespace}-rows]`);
 const templateRow = rowsBody ? rowsBody.querySelector (`tr[data-${namespace}-template]`) : null;
 const addButton = document.getElementById (`add-${namespace}`);
@@ -551,7 +594,7 @@ return;
 deleteLink.addEventListener('click', function (event) {
 event.preventDefault();
 const visibleRows = getVisibleRows();
-if (visibleRows.length<= 1) {
+if (requireMinimumRow && visibleRows.length<= 1) {
                                 resetRowInputs(row);
                                 return;
                             }
@@ -599,7 +642,9 @@ rowsBody.insertBefore(row, templateRow);
 }
 };
 
+if (requireMinimumRow) {
 ensureRowPresent();
+}
 
 if (addButton) {
 addButton.addEventListener('click', function (event) {
@@ -613,7 +658,7 @@ rowsBody.insertBefore(row, templateRow);
 }
 };
 
-setupDynamicRows('performer');
+setupDynamicRows('performer', {requireMinimumRow: false});
 setupDynamicRows('productionTeam');
 setupDynamicRows('sponsorship');
 
@@ -680,7 +725,14 @@ isSaving = false;
 });
 });
 
-form.addEventListener('htmx:afterRequest', function () {
+form.addEventListener('htmx:afterRequest', function (event) {
+// This listener is attached to the form to catch its own hx-post submission,
+// but htmx:afterRequest bubbles from any descendant — including the "+ New …"
+// quick-create buttons nested inside this form. Ignore those so quick-create
+// clicks don't yank the page up to #flash-messages.
+if (event.detail && event.detail.elt !== form) {
+return;
+}
 isSaving = false;
 document.getElementById('flash-messages') ?. scrollIntoView({behavior: 'smooth', block: 'nearest'});
 });
@@ -695,4 +747,23 @@ byUrl: '/admin/productions/images/fetch'
 }));
 });
 </script>
+<script type="module">
+	import {initQuickCreateHandlers, buildVenueFallback, buildSponsorshipTableFallback} from '/assets/js/production-quick-create.js';
+
+	initQuickCreateHandlers({
+		person: {
+			type: 'rowset-group',
+			contextAttr: 'qcPersonTarget',
+			candidates: [
+				{namespace: 'performer', selectName: 'performerIds[]'},
+				{namespace: 'productionTeam', selectName: 'productionTeamIds[]'},
+			],
+		},
+		work: {type: 'multiselect', id: 'works'},
+		venue: {type: 'single', selectName: 'venueId', buildFallback: buildVenueFallback},
+		sponsor: {type: 'rowset', namespace: 'sponsorship', selectName: 'sponsorshipSponsorIds[]', buildFallback: buildSponsorshipTableFallback},
+	});
+</script>
+
+{% include 'admin/productions/_quick_create_modal.html.twig' %}
 {% endblock %}

--- a/templates/admin/sponsors/_quick_create_modal.html.twig
+++ b/templates/admin/sponsors/_quick_create_modal.html.twig
@@ -1,0 +1,41 @@
+<div class="flex items-center justify-between px-6 py-4 border-b border-gray-200">
+	<h2 class="text-lg font-semibold text-gray-900">Add New Sponsor</h2>
+	<button type="button" onclick="document.getElementById('quick-create-modal').close()" class="text-gray-400 hover:text-gray-600 focus:outline-none" aria-label="Close">
+		<svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="18" y1="6" x2="6" y2="18"/><line x1="6" y1="6" x2="18" y2="18"/></svg>
+	</button>
+</div>
+
+<div id="modal-flash" class="px-6 pt-4"></div>
+
+<form id="quick-create-form"
+      hx-post="/admin/sponsors/quick-create"
+      hx-target="#modal-flash"
+      hx-swap="innerHTML"
+      class="px-6 pb-6 space-y-4">
+	<div>
+		<label for="qc-name" class="block text-sm font-medium text-gray-700 mb-1">Sponsor Name <span class="text-red-500">*</span></label>
+		<input type="text" name="name" id="qc-name" required
+		       class="w-full rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500"
+		       placeholder="e.g. Acme Corporation">
+	</div>
+
+	<div>
+		<label for="qc-websiteUrl" class="block text-sm font-medium text-gray-700 mb-1">Website URL <span class="text-gray-400 font-normal">(optional)</span></label>
+		<input type="url" name="websiteUrl" id="qc-websiteUrl"
+		       class="w-full rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500"
+		       placeholder="https://example.com">
+	</div>
+
+	<p class="text-xs text-gray-500">Sponsor logo and additional details can be added later from the Sponsors section.</p>
+
+	<div class="flex justify-end gap-3 pt-2 border-t border-gray-100">
+		<button type="button" onclick="document.getElementById('quick-create-modal').close()"
+		        class="px-4 py-2 text-sm font-medium text-gray-700 bg-white border border-gray-300 rounded-md hover:bg-gray-50">
+			Cancel
+		</button>
+		<button type="submit"
+		        class="px-4 py-2 text-sm font-medium text-white bg-blue-600 rounded-md hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500">
+			Add Sponsor
+		</button>
+	</div>
+</form>

--- a/templates/admin/venues/_quick_create_modal.html.twig
+++ b/templates/admin/venues/_quick_create_modal.html.twig
@@ -1,0 +1,60 @@
+<div class="flex items-center justify-between px-6 py-4 border-b border-gray-200">
+	<h2 class="text-lg font-semibold text-gray-900">Add New Venue</h2>
+	<button type="button" onclick="document.getElementById('quick-create-modal').close()" class="text-gray-400 hover:text-gray-600 focus:outline-none" aria-label="Close">
+		<svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="18" y1="6" x2="6" y2="18"/><line x1="6" y1="6" x2="18" y2="18"/></svg>
+	</button>
+</div>
+
+<div id="modal-flash" class="px-6 pt-4"></div>
+
+<form id="quick-create-form"
+      hx-post="/admin/venues/quick-create"
+      hx-target="#modal-flash"
+      hx-swap="innerHTML"
+      class="px-6 pb-6 space-y-4">
+	<div>
+		<label for="qc-name" class="block text-sm font-medium text-gray-700 mb-1">Venue Name <span class="text-red-500">*</span></label>
+		<input type="text" name="name" id="qc-name" required
+		       class="w-full rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500"
+		       placeholder="e.g. The Mainstage Theater">
+	</div>
+
+	<div>
+		<label for="qc-address" class="block text-sm font-medium text-gray-700 mb-1">Street Address <span class="text-red-500">*</span></label>
+		<input type="text" name="address" id="qc-address" required
+		       class="w-full rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500"
+		       placeholder="123 Main St">
+	</div>
+
+	<div class="grid grid-cols-2 gap-4">
+		<div>
+			<label for="qc-city" class="block text-sm font-medium text-gray-700 mb-1">City <span class="text-red-500">*</span></label>
+			<input type="text" name="city" id="qc-city" required
+			       class="w-full rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500">
+		</div>
+		<div>
+			<label for="qc-state" class="block text-sm font-medium text-gray-700 mb-1">State <span class="text-red-500">*</span></label>
+			<input type="text" name="state" id="qc-state" required
+			       class="w-full rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500">
+		</div>
+	</div>
+
+	<div class="w-1/2">
+		<label for="qc-postcode" class="block text-sm font-medium text-gray-700 mb-1">Postcode <span class="text-red-500">*</span></label>
+		<input type="text" name="postcode" id="qc-postcode" required
+		       class="w-full rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500">
+	</div>
+
+	<p class="text-xs text-gray-500">Capacity, website, accessibility info, and other details can be added later from the Venues section.</p>
+
+	<div class="flex justify-end gap-3 pt-2 border-t border-gray-100">
+		<button type="button" onclick="document.getElementById('quick-create-modal').close()"
+		        class="px-4 py-2 text-sm font-medium text-gray-700 bg-white border border-gray-300 rounded-md hover:bg-gray-50">
+			Cancel
+		</button>
+		<button type="submit"
+		        class="px-4 py-2 text-sm font-medium text-white bg-blue-600 rounded-md hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500">
+			Add Venue
+		</button>
+	</div>
+</form>

--- a/templates/admin/works/_quick_create_modal.html.twig
+++ b/templates/admin/works/_quick_create_modal.html.twig
@@ -1,0 +1,72 @@
+{% set people = people|default([]) %}
+
+<div class="flex items-center justify-between px-6 py-4 border-b border-gray-200">
+	<h2 class="text-lg font-semibold text-gray-900">Add New Work</h2>
+	<button type="button" onclick="document.getElementById('quick-create-modal').close()" class="text-gray-400 hover:text-gray-600 focus:outline-none" aria-label="Close">
+		<svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="18" y1="6" x2="6" y2="18"/><line x1="6" y1="6" x2="18" y2="18"/></svg>
+	</button>
+</div>
+
+<div id="modal-flash" class="px-6 pt-4"></div>
+
+<form id="quick-create-form"
+      hx-post="/admin/works/quick-create"
+      hx-target="#modal-flash"
+      hx-swap="innerHTML"
+      class="px-6 pb-6 space-y-4">
+	<div>
+		<label for="qc-title" class="block text-sm font-medium text-gray-700 mb-1">Title <span class="text-red-500">*</span></label>
+		<input type="text" name="title" id="qc-title" required
+		       class="w-full rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500"
+		       placeholder="e.g. Hamlet">
+	</div>
+
+	<div class="border border-gray-200 rounded-md p-4 space-y-3 bg-gray-50">
+		<p class="text-sm font-medium text-gray-700">Creator <span class="text-gray-400 font-normal">(optional)</span></p>
+
+		{% if people is empty %}
+			<div class="text-xs text-gray-500 flex items-center gap-2">
+				<span>No people yet.</span>
+				<button type="button"
+				        class="inline-flex items-center gap-1 px-2 py-1 text-xs font-medium text-blue-700 bg-blue-50 border border-blue-200 rounded hover:bg-blue-100"
+				        hx-get="/admin/people/quick-create"
+				        hx-target="#quick-create-modal-content"
+				        hx-swap="innerHTML">
+					+ Add a Person first
+				</button>
+			</div>
+		{% else %}
+			<div class="grid grid-cols-2 gap-3">
+				<div>
+					<label for="qc-creatorId" class="block text-xs font-medium text-gray-600 mb-1">Person</label>
+					<select name="creatorId" id="qc-creatorId"
+					        class="w-full rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500 text-sm">
+						<option value="">None</option>
+						{% for p in people %}
+							<option value="{{ p.id }}">{{ p.name }}</option>
+						{% endfor %}
+					</select>
+				</div>
+				<div>
+					<label for="qc-creatorRole" class="block text-xs font-medium text-gray-600 mb-1">Role</label>
+					<input type="text" name="creatorRole" id="qc-creatorRole"
+					       class="w-full rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500 text-sm"
+					       placeholder="e.g. Playwright">
+				</div>
+			</div>
+		{% endif %}
+	</div>
+
+	<p class="text-xs text-gray-500">Description, synopsis, and additional creators can be added later from the Works section.</p>
+
+	<div class="flex justify-end gap-3 pt-2 border-t border-gray-100">
+		<button type="button" onclick="document.getElementById('quick-create-modal').close()"
+		        class="px-4 py-2 text-sm font-medium text-gray-700 bg-white border border-gray-300 rounded-md hover:bg-gray-50">
+			Cancel
+		</button>
+		<button type="submit"
+		        class="px-4 py-2 text-sm font-medium text-white bg-blue-600 rounded-md hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500">
+			Add Work
+		</button>
+	</div>
+</form>

--- a/www/assets/js/production-quick-create.js
+++ b/www/assets/js/production-quick-create.js
@@ -1,0 +1,284 @@
+// Wires up the "+ New …" quick-create modal buttons on the production create/edit pages.
+// When a controller's quickStore() action succeeds it responds with an HX-Trigger:
+// entityCreated header carrying { id, name, type }. We listen for that and drop the
+// freshly created record into the relevant <select> on the page instead of forcing a
+// full page reload, so the user never has to leave the production form.
+
+function buildOption(id, name) {
+    const option = document.createElement('option');
+    option.value = id;
+    option.textContent = name;
+    return option;
+}
+
+// searchable-select.js wraps an enhanced <select> in a `.space-y-1` div alongside the
+// visible text <input> and its <datalist>. Appending an <option> to the (now hidden)
+// select alone does not update what the user sees, so both must be kept in sync here.
+function searchableWrapperFor(select) {
+    return select.closest('.space-y-1');
+}
+
+function addDatalistEntry(select, id, name) {
+    const wrapper = searchableWrapperFor(select);
+    const datalist = wrapper ? wrapper.querySelector('datalist') : null;
+    if (!datalist) {
+        return;
+    }
+    const entry = document.createElement('option');
+    entry.value = name;
+    entry.dataset.optionValue = String(id);
+    datalist.appendChild(entry);
+}
+
+function selectValue(select, id, name) {
+    select.value = String(id);
+    const wrapper = searchableWrapperFor(select);
+    const input = wrapper ? wrapper.querySelector('input[type="text"]') : null;
+    if (input) {
+        input.value = name;
+    }
+}
+
+function appendOptionTo(select, id, name) {
+    select.appendChild(buildOption(id, name));
+    addDatalistEntry(select, id, name);
+}
+
+function populateSingleSelect(selectName, id, name, buildFallback) {
+    const select = document.querySelector(`select[name="${selectName}"]`);
+    if (select) {
+        appendOptionTo(select, id, name);
+        selectValue(select, id, name);
+        return;
+    }
+    if (typeof buildFallback === 'function') {
+        buildFallback(id, name);
+    }
+}
+
+function populateMultiSelect(elementId, id, name) {
+    const select = document.getElementById(elementId);
+    if (!select) {
+        return;
+    }
+    const option = buildOption(id, name);
+    option.selected = true;
+    select.appendChild(option);
+}
+
+function appendOptionToNamespace(namespace, selectName, id, name) {
+    const rowsBody = document.querySelector(`tbody[data-${namespace}-rows]`);
+    if (!rowsBody) {
+        return;
+    }
+    Array.from(rowsBody.querySelectorAll(`select[name="${selectName}"]`)).forEach((select) => {
+        appendOptionTo(select, id, name);
+    });
+}
+
+// Selects the newly created record into the first row that doesn't already have a
+// selection; if every row is taken, a new row is added (via the section's own
+// "Add …" button) and the selection is placed there instead of overwriting an
+// existing row's choice.
+function selectIntoNamespace(namespace, selectName, id, name) {
+    const rowsBody = document.querySelector(`tbody[data-${namespace}-rows]`);
+    if (!rowsBody) {
+        return;
+    }
+
+    // The "Add …" button starts disabled when its source list (e.g. people) is
+    // empty. Having just created a record for that list, re-enable it before
+    // possibly relying on it below to add a row.
+    const addButton = document.getElementById(`add-${namespace}`);
+    if (addButton && addButton.disabled) {
+        addButton.disabled = false;
+        addButton.classList.remove('opacity-50', 'cursor-not-allowed');
+    }
+
+    const rowSelects = Array.from(rowsBody.querySelectorAll(`tr[data-${namespace}-row] select[name="${selectName}"]`));
+    let target = rowSelects.find((select) => !select.value);
+
+    if (!target) {
+        if (addButton) {
+            addButton.click();
+        }
+        const refreshed = Array.from(rowsBody.querySelectorAll(`tr[data-${namespace}-row] select[name="${selectName}"]`));
+        target = refreshed[refreshed.length - 1];
+    }
+
+    if (target) {
+        selectValue(target, id, name);
+    }
+}
+
+export function buildVenueFallback(id, name) {
+    const placeholder = document.getElementById('venueId-empty-placeholder');
+    if (!placeholder) {
+        return;
+    }
+
+    const select = document.createElement('select');
+    select.name = 'venueId';
+    select.id = 'venueId';
+    select.className = 'w-full rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500';
+
+    const blank = document.createElement('option');
+    blank.value = '';
+    blank.textContent = 'Select a venue';
+    select.appendChild(blank);
+    select.appendChild(buildOption(id, name));
+    select.value = String(id);
+
+    placeholder.replaceWith(select);
+}
+
+// The sponsorship table (like the venue select) isn't rendered at all when the
+// production starts with zero sponsors, so there is nowhere for a rowset select to
+// attach to until one exists. Build the same markup the "not empty" branch of the
+// template renders, wire up its Delete link, and re-enable the Add Sponsorship button.
+export function buildSponsorshipTableFallback(id, name) {
+    const placeholder = document.getElementById('sponsorship-empty-placeholder');
+    if (!placeholder) {
+        return;
+    }
+
+    const wrapper = document.createElement('div');
+    wrapper.className = 'relative overflow-x-auto bg-white border border-gray-200 shadow-sm rounded-md';
+    wrapper.innerHTML = `
+        <table class="w-full text-sm text-left text-gray-700">
+            <thead class="bg-gray-50 text-xs uppercase tracking-wide text-gray-500 border-b border-gray-200">
+                <tr>
+                    <th class="px-4 py-3 font-medium">Sponsor</th>
+                    <th class="px-4 py-3 font-medium text-right">Action</th>
+                </tr>
+            </thead>
+            <tbody data-sponsorship-rows>
+                <tr class="bg-white border-b border-gray-100" data-sponsorship-row>
+                    <th scope="row" class="px-4 py-3 font-medium text-gray-900">
+                        <select name="sponsorshipSponsorIds[]" class="w-full rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500">
+                            <option value="">Select a sponsor</option>
+                        </select>
+                    </th>
+                    <td class="px-4 py-3 text-right">
+                        <a href="#" class="delete-sponsorship font-medium text-blue-600 hover:underline">Delete</a>
+                    </td>
+                </tr>
+                <tr class="hidden bg-white border-b border-gray-100" data-sponsorship-template>
+                    <th scope="row" class="px-4 py-3 font-medium text-gray-900">
+                        <select name="sponsorshipSponsorIds[]" class="w-full rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500">
+                            <option value="">Select a sponsor</option>
+                        </select>
+                    </th>
+                    <td class="px-4 py-3 text-right">
+                        <a href="#" class="delete-sponsorship font-medium text-blue-600 hover:underline">Delete</a>
+                    </td>
+                </tr>
+            </tbody>
+        </table>
+    `;
+
+    placeholder.replaceWith(wrapper);
+
+    const select = wrapper.querySelector('tr[data-sponsorship-row] select');
+    if (select) {
+        select.appendChild(buildOption(id, name));
+        select.value = String(id);
+    }
+
+    const addButton = document.getElementById('add-sponsorship');
+    if (addButton) {
+        addButton.disabled = false;
+        addButton.classList.remove('opacity-50', 'cursor-not-allowed');
+    }
+}
+
+function applyHandler(handler, id, name) {
+    if (handler.type === 'single') {
+        populateSingleSelect(handler.selectName, id, name, handler.buildFallback);
+    } else if (handler.type === 'multiselect') {
+        populateMultiSelect(handler.id, id, name);
+    } else if (handler.type === 'rowset') {
+        const rowsBody = document.querySelector(`tbody[data-${handler.namespace}-rows]`);
+        if (!rowsBody) {
+            if (typeof handler.buildFallback === 'function') {
+                handler.buildFallback(id, name);
+            }
+            return;
+        }
+        appendOptionToNamespace(handler.namespace, handler.selectName, id, name);
+        selectIntoNamespace(handler.namespace, handler.selectName, id, name);
+    } else if (handler.type === 'rowset-group') {
+        handler.candidates.forEach((candidate) => {
+            appendOptionToNamespace(candidate.namespace, candidate.selectName, id, name);
+        });
+
+        const contextValue = handler.contextAttr ? document.body.dataset[handler.contextAttr] : null;
+        const target = handler.candidates.find((candidate) => candidate.namespace === contextValue) || handler.candidates[0];
+        selectIntoNamespace(target.namespace, target.selectName, id, name);
+    }
+}
+
+// The project pins htmx 1.9.2, which predates the hx-on:<event> / hx-on::<htmx-event>
+// attribute shorthand (only the older single hx-on="event:code" attribute is
+// supported by that version's attribute scanner). The "+ New …" buttons therefore
+// can't declare `hx-on::after-request="…showModal()…"` inline — that attribute is
+// silently inert on 1.9.2, so the modal's content loads but the dialog never opens.
+// htmx:afterRequest itself is core functionality present in every version, so we
+// open the modal from a real listener instead, keyed off the swap target.
+function openModalAfterQuickCreateLoad(event) {
+    var target = event.detail && event.detail.target;
+    if (!target || target.id !== 'quick-create-modal-content') {
+        return;
+    }
+    var modal = document.getElementById('quick-create-modal');
+    if (!modal) {
+        return;
+    }
+
+    // Nested case: the "Add a Person/Venue first" button inside an already-open
+    // modal swaps #quick-create-modal-content again without closing the dialog.
+    // Calling showModal() on an already-open <dialog> throws, so skip it then.
+    if (typeof modal.showModal === 'function' && !modal.open) {
+        modal.showModal();
+    }
+
+    // Focus the form's first field ourselves instead of relying on an
+    // `autofocus` attribute on the swapped-in markup: showModal()'s native
+    // autofocus handling can trigger a page-level scroll-into-view before the
+    // dialog has actually finished becoming a top-layer element, which is what
+    // was causing the page to jump to the top on every "+ New …" click.
+    // preventScroll keeps the focus purely inside the (already on-screen) dialog.
+    var firstField = target.querySelector('input, select, textarea');
+    if (firstField && typeof firstField.focus === 'function') {
+        firstField.focus({ preventScroll: true });
+    }
+}
+
+// config maps entityCreated "type" values (person | work | venue | sponsor) to a
+// handler descriptor. See create.html.twig / edit.html.twig for the shapes in use.
+// How long the "X was added." success alert stays visible in the modal before
+// it auto-closes. Long enough to read a short message, short enough to still
+// feel instant for the "just let me get back to the production form" flow.
+const SUCCESS_CLOSE_DELAY_MS = 900;
+
+export function initQuickCreateHandlers(config) {
+    document.body.addEventListener('htmx:afterRequest', openModalAfterQuickCreateLoad);
+
+    document.body.addEventListener('entityCreated', function (event) {
+        const { id, name, type } = event.detail;
+        const handler = config[type];
+        if (handler) {
+            applyHandler(handler, id, name);
+        }
+
+        // The success alert was just swapped into #modal-flash by the same
+        // response that triggered this event; give it a moment on screen
+        // before closing the modal instead of closing instantly.
+        window.setTimeout(function () {
+            const modal = document.getElementById('quick-create-modal');
+            if (modal && modal.open) {
+                modal.close();
+            }
+        }, SUCCESS_CLOSE_DELAY_MS);
+    });
+}


### PR DESCRIPTION
This pull request introduces a "quick-create" feature for People, Sponsors, Venues, and Works in the admin interface, allowing users to add these entities via modal dialogs without leaving the current page. It also improves the handling of related data when creating Productions and refines several model definitions for better nullability and type safety.

**Quick-create feature for admin entities:**

* Added new routes and controller actions for `/quick-create` endpoints for People, Sponsors, Venues, and Works, enabling modal-based creation via HTMX and returning alerts and triggers for frontend updates. (`app/routes/admin/people.php`, `app/routes/admin/sponsors.php`, `app/routes/admin/venues.php`, `app/routes/admin/works.php`, `PersonController.php`, `SponsorController.php`, `VenueController.php`, `WorksController.php`) [[1]](diffhunk://#diff-d36d441dab46de03787e03cc205b78ec2903270e1cc9f002db17f74a11237e6dR14-R15) [[2]](diffhunk://#diff-cc752598cacd6f6a00eb79323efc7776803c17af551d50687c51f0b3519efb95R14-R15) [[3]](diffhunk://#diff-fc8f941fcfbdd59cf4143f9d1a4f4aebc6b8fbfcf4cffce61f36c6a7412d99fcR14-R15) [[4]](diffhunk://#diff-493709c0542dc0b2d441186f2b9a70cdcd2a768d10d2f3ea543047ae3d19b964R14-R15) [[5]](diffhunk://#diff-22a11eb51165ac97704351ea6d9b290c744df8bb437a8a635fbad09205f93bb7R88-R126) [[6]](diffhunk://#diff-b3124700aef2ec335e8116da936b72f73e36bc1676d860116ae64733c2eb2c27R122-R160) [[7]](diffhunk://#diff-a5f46490fc858c10a6de51a8dddfffb3a479b682f53c567da06acd603da06bf2R96-R137) [[8]](diffhunk://#diff-81d72c0b98f303640b884cf0ec7c04349a659cd68db1018041a748dc9c7b50e0R91-R143)
* Added modal templates for quick-creating People, Sponsors, Venues, and Works, including forms and UI for rapid entry. (`templates/admin/people/_quick_create_modal.html.twig`, `templates/admin/productions/_quick_create_modal.html.twig`) [[1]](diffhunk://#diff-6c752a958ca894fba9056062ebf3d24f617ffca7c9d289c8b275c90e2e713702R1-R42) [[2]](diffhunk://#diff-53902fdf60fe283ecf25e44530ab19f93f673663bd6d0309f8f60ae8ee995b01R1-R8)

**Production creation improvements:**

* Enhanced `ProductionController` to support attaching creative and performer people (with roles) when creating a production, improving the workflow for associating related entities. (`ProductionController.php`)
* Updated the production creation template to remove warnings about missing works or people, streamline venue selection, and improve the featured image upload UI. (`templates/admin/productions/create.html.twig`) [[1]](diffhunk://#diff-f56460794657fe5dd5b23e890af1c0c412b50b027f08057a7146b38e8e2e6940L41-L82) [[2]](diffhunk://#diff-f56460794657fe5dd5b23e890af1c0c412b50b027f08057a7146b38e8e2e6940L110-L124) [[3]](diffhunk://#diff-f56460794657fe5dd5b23e890af1c0c412b50b027f08057a7146b38e8e2e6940R85-R100)

**Model and type safety improvements:**

* Updated `Person` and `Sponsor` models to allow `null` for optional fields like biography, headshot, logo, and website URLs, improving type safety and preventing possible errors. (`Person.php`, `Sponsor.php`) [[1]](diffhunk://#diff-d662ec777e239cb632efb54237e5640c819c27e374170c173b0030f1e6969f4dL73-R79) [[2]](diffhunk://#diff-62e6058bc65aba628ef552a3c12ae5c42e613c030536afd45f403e8147e7f863L24-R27) [[3]](diffhunk://#diff-62e6058bc65aba628ef552a3c12ae5c42e613c030536afd45f403e8147e7f863L54-R71)