### PR TITLE
Add base styles and content status management for EditorJS

### DIFF
--- a/app/routes/frontend/pages.php
+++ b/app/routes/frontend/pages.php
@@ -14,7 +14,7 @@ if (isset($app)) {
         $repository = $container->get(PageRepository::class);
         $page = $repository->fetchBySlug($args['slug']);
 
-        if (!$page) {
+        if (!$page || !$page->isPublished()) {
             $response->getBody()->write('Page not found');
 
             return $response->withStatus(404);

--- a/migrations/20260820_add_status_to_pages.sql
+++ b/migrations/20260820_add_status_to_pages.sql
@@ -1,0 +1,8 @@
+ALTER TABLE `pages`
+    ADD COLUMN `status` VARCHAR(32) NOT NULL DEFAULT 'published' AFTER `title`;
+
+-- Match posts.status exactly: no DB-level default, the app always supplies
+-- a status explicitly. The DEFAULT above only exists to backfill existing
+-- rows as 'published' (they predate this column and were already live).
+ALTER TABLE `pages`
+    ALTER COLUMN `status` DROP DEFAULT;

--- a/src/Controllers/PageController.php
+++ b/src/Controllers/PageController.php
@@ -6,6 +6,7 @@ use Doctrine\ORM\EntityManagerInterface;
 use Psr\Http\Message\ResponseInterface as Response;
 use Psr\Http\Message\ServerRequestInterface as Request;
 use Slim\Views\Twig;
+use TheatreCMS\Enums\ContentStatus;
 use TheatreCMS\Repositories\PageRepository;
 
 /**
@@ -25,13 +26,21 @@ class PageController extends BaseController
         return $this->twig->render(
             $response,
             'admin/pages/index.html.twig',
-            $this->buildPaginatedViewData($request, $this->repository, 'pages', '/admin/pages')
+            $this->buildPaginatedViewData(
+                $request,
+                $this->repository,
+                'pages',
+                '/admin/pages',
+                ['statuses' => ContentStatus::labels()]
+            )
         );
     }
 
     public function create(Request $request, Response $response, array $args = []): Response
     {
-        return $this->twig->render($response, 'admin/pages/create.html.twig');
+        return $this->twig->render($response, 'admin/pages/create.html.twig', [
+            'statuses' => ContentStatus::labels(),
+        ]);
     }
 
     public function edit(Request $request, Response $response, array $args = []): Response
@@ -43,7 +52,8 @@ class PageController extends BaseController
         }
 
         return $this->twig->render($response, 'admin/pages/edit.html.twig', [
-            'page' => $page,
+            'page'     => $page,
+            'statuses' => ContentStatus::labels(),
         ]);
     }
 
@@ -58,7 +68,13 @@ class PageController extends BaseController
             }
         }
 
-        $data = $this->buildPaginatedViewData($request, $this->repository, 'pages', '/admin/pages');
+        $data = $this->buildPaginatedViewData(
+            $request,
+            $this->repository,
+            'pages',
+            '/admin/pages',
+            ['statuses' => ContentStatus::labels()]
+        );
 
         if ($request->getHeaderLine('HX-Request')) {
             return $this->twig->render($response, 'admin/pages/_list.html.twig', $data);
@@ -84,6 +100,7 @@ class PageController extends BaseController
         try {
             $this->repository->create([
                 'title'   => $data['title'] ?? null,
+                'status'  => $data['status'] ?? ContentStatus::DRAFT->value,
                 'content' => $data['content'] ?? null,
             ]);
         } catch (\InvalidArgumentException $e) {
@@ -120,7 +137,7 @@ class PageController extends BaseController
         }
 
         $data = $this->parseArgs($data, [
-            'pageId' => 0, 'title' => null, 'content' => null, 'slug' => null,
+            'pageId' => 0, 'title' => null, 'status' => ContentStatus::DRAFT->value, 'content' => null, 'slug' => null,
         ]);
 
         $page = $this->repository->fetch((int) $data['pageId']);
@@ -143,7 +160,18 @@ class PageController extends BaseController
             return $response->withStatus(400);
         }
 
+        $status = ContentStatus::tryFrom($data['status']);
+        if ($status === null) {
+            if ($isHtmx) {
+                return $this->twig->render($response, 'admin/partials/_alert.html.twig', [
+                    'type' => 'error', 'message' => 'Invalid status.',
+                ]);
+            }
+            return $response->withStatus(400);
+        }
+
         $page->setTitle($data['title']);
+        $page->setStatus($status);
         $page->setContent($data['content']);
         $page->touchModified();
 

--- a/src/Controllers/PostController.php
+++ b/src/Controllers/PostController.php
@@ -8,7 +8,7 @@ use Psr\Http\Message\ResponseInterface as Response;
 use Psr\Http\Message\ServerRequestInterface as Request;
 use Psr\Http\Message\UploadedFileInterface;
 use Slim\Views\Twig;
-use TheatreCMS\Enums\PostStatus;
+use TheatreCMS\Enums\ContentStatus;
 use TheatreCMS\Repositories\PostRepository;
 use TheatreCMS\Services\ImageUploadService;
 
@@ -37,7 +37,7 @@ class PostController extends BaseController
                 $this->repository,
                 'posts',
                 '/admin/posts',
-                ['statuses' => PostStatus::labels()]
+                ['statuses' => ContentStatus::labels()]
             )
         );
     }
@@ -45,7 +45,7 @@ class PostController extends BaseController
     public function create(Request $request, Response $response, array $args = []): Response
     {
         return $this->twig->render($response, 'admin/posts/create.html.twig', [
-            'statuses' => PostStatus::labels(),
+            'statuses' => ContentStatus::labels(),
         ]);
     }
 
@@ -59,7 +59,7 @@ class PostController extends BaseController
 
         return $this->twig->render($response, 'admin/posts/edit.html.twig', [
             'post'     => $post,
-            'statuses' => PostStatus::labels(),
+            'statuses' => ContentStatus::labels(),
         ]);
     }
 
@@ -80,8 +80,8 @@ class PostController extends BaseController
             'posts',
             '/admin/posts',
             [
-                'statuses' => PostStatus::labels(),
-                'status_labels' => PostStatus::labels(),
+                'statuses' => ContentStatus::labels(),
+                'status_labels' => ContentStatus::labels(),
             ]
         );
 
@@ -136,7 +136,7 @@ class PostController extends BaseController
         try {
             $this->repository->create([
                 'title' => $data['title'] ?? null,
-                'status' => $data['status'] ?? PostStatus::DRAFT->value,
+                'status' => $data['status'] ?? ContentStatus::DRAFT->value,
                 'content' => $data['content'] ?? null,
                 'featuredImageUrl' => $data['featuredImageUrl'] ?? null,
             ]);
@@ -178,7 +178,7 @@ class PostController extends BaseController
         $data = $this->parseArgs($data, [
             'postId' => 0,
             'title' => null,
-            'status' => PostStatus::DRAFT->value,
+            'status' => ContentStatus::DRAFT->value,
             'content' => null,
             'slug' => null,
             'publishedAt' => null,
@@ -212,7 +212,7 @@ class PostController extends BaseController
             return $response->withStatus(400);
         }
 
-        $status = PostStatus::tryFrom($data['status']);
+        $status = ContentStatus::tryFrom($data['status']);
         if ($status === null) {
             if ($request->getHeaderLine('HX-Request')) {
                 return $this->twig->render($response, 'admin/partials/_alert.html.twig', [
@@ -232,7 +232,7 @@ class PostController extends BaseController
         if (!empty($data['publishedAt'])) {
             $parsedDate = DateTimeImmutable::createFromFormat('Y-m-d\TH:i', $data['publishedAt']);
             $post->setPublishedAt($parsedDate ?: null);
-        } elseif ($status === PostStatus::PUBLISHED && $post->getPublishedAt() === null) {
+        } elseif ($status === ContentStatus::PUBLISHED && $post->getPublishedAt() === null) {
             $post->setPublishedAt(new DateTimeImmutable());
         } else {
             $post->setPublishedAt(null);

--- a/src/Enums/ContentStatus.php
+++ b/src/Enums/ContentStatus.php
@@ -2,7 +2,13 @@
 
 namespace TheatreCMS\Enums;
 
-enum PostStatus: string
+/**
+ * Shared editorial status for content types that need a draft/published
+ * workflow — currently Posts and Pages. Seasons, Productions, and Events are
+ * expected to adopt this same enum (via TheatreCMS\Traits\HasContentStatus)
+ * rather than each defining their own parallel status type.
+ */
+enum ContentStatus: string
 {
     case DRAFT = 'draft';
     case PUBLISHED = 'published';

--- a/src/Models/Page.php
+++ b/src/Models/Page.php
@@ -8,10 +8,14 @@ use Doctrine\ORM\Mapping\Entity;
 use Doctrine\ORM\Mapping\GeneratedValue;
 use Doctrine\ORM\Mapping\Id;
 use Doctrine\ORM\Mapping\Table;
+use TheatreCMS\Enums\ContentStatus;
+use TheatreCMS\Traits\HasContentStatus;
 
 #[Entity, Table(name: 'pages')]
 class Page extends ModelBase
 {
+    use HasContentStatus;
+
     #[Id, Column(type: 'integer'), GeneratedValue(strategy: 'AUTO')]
     private int $id;
 
@@ -27,9 +31,10 @@ class Page extends ModelBase
     #[Column(name: 'modified_at', type: 'datetime_immutable')]
     private DateTimeImmutable $modifiedAt;
 
-    public function __construct(string $title, string $content)
+    public function __construct(string $title, ContentStatus $status, string $content)
     {
         $this->title = $title;
+        $this->status = $status;
         $this->content = $content;
         $this->createdAt = new DateTimeImmutable();
         $this->modifiedAt = new DateTimeImmutable();

--- a/src/Models/Post.php
+++ b/src/Models/Post.php
@@ -8,19 +8,19 @@ use Doctrine\ORM\Mapping\Entity;
 use Doctrine\ORM\Mapping\GeneratedValue;
 use Doctrine\ORM\Mapping\Id;
 use Doctrine\ORM\Mapping\Table;
-use TheatreCMS\Enums\PostStatus;
+use TheatreCMS\Enums\ContentStatus;
+use TheatreCMS\Traits\HasContentStatus;
 
 #[Entity, Table(name: 'posts')]
 class Post extends ModelBase
 {
+    use HasContentStatus;
+
     #[Id, Column(type: 'integer'), GeneratedValue(strategy: 'AUTO')]
     private int $id;
 
     #[Column(type: 'string', length: 255, nullable: false)]
     private string $title;
-
-    #[Column(type: 'string', length: 32, nullable: false, enumType: PostStatus::class)]
-    private PostStatus $status;
 
     #[Column(type: 'text', nullable: false)]
     private string $content;
@@ -37,7 +37,7 @@ class Post extends ModelBase
     #[Column(name: 'published_at', type: 'datetime_immutable', nullable: true)]
     private ?DateTimeImmutable $publishedAt = null;
 
-    public function __construct(string $title, PostStatus $status, string $content)
+    public function __construct(string $title, ContentStatus $status, string $content)
     {
         $this->title = $title;
         $this->status = $status;
@@ -45,7 +45,7 @@ class Post extends ModelBase
         $this->createdAt = new DateTimeImmutable();
         $this->modifiedAt = new DateTimeImmutable();
 
-        if ($status === PostStatus::PUBLISHED) {
+        if ($status === ContentStatus::PUBLISHED) {
             $this->publishedAt = new DateTimeImmutable();
         }
     }
@@ -63,18 +63,6 @@ class Post extends ModelBase
     public function setTitle(string $title): self
     {
         $this->title = $title;
-
-        return $this;
-    }
-
-    public function getStatus(): PostStatus
-    {
-        return $this->status;
-    }
-
-    public function setStatus(PostStatus $status): self
-    {
-        $this->status = $status;
 
         return $this;
     }
@@ -135,10 +123,5 @@ class Post extends ModelBase
         $this->publishedAt = $publishedAt;
 
         return $this;
-    }
-
-    public function isPublished(): bool
-    {
-        return $this->status === PostStatus::PUBLISHED;
     }
 }

--- a/src/Repositories/PageRepository.php
+++ b/src/Repositories/PageRepository.php
@@ -2,6 +2,7 @@
 
 namespace TheatreCMS\Repositories;
 
+use TheatreCMS\Enums\ContentStatus;
 use TheatreCMS\Models\Page;
 
 class PageRepository extends BaseRepository
@@ -12,6 +13,7 @@ class PageRepository extends BaseRepository
     {
         $args = array_merge([
             'title' => null,
+            'status' => ContentStatus::DRAFT->value,
             'content' => null,
             'slug' => null,
         ], $args);
@@ -24,7 +26,12 @@ class PageRepository extends BaseRepository
             throw new \InvalidArgumentException('Content is required.');
         }
 
-        $page = new Page($args['title'], $args['content']);
+        $status = ContentStatus::tryFrom($args['status']);
+        if ($status === null) {
+            throw new \InvalidArgumentException('Invalid status.');
+        }
+
+        $page = new Page($args['title'], $status, $args['content']);
         $slugSource = $args['slug'] ?? $args['title'];
         $page->setSlug($this->generateUniqueSlug($slugSource));
 

--- a/src/Repositories/PostRepository.php
+++ b/src/Repositories/PostRepository.php
@@ -2,7 +2,7 @@
 
 namespace TheatreCMS\Repositories;
 
-use TheatreCMS\Enums\PostStatus;
+use TheatreCMS\Enums\ContentStatus;
 use TheatreCMS\Models\Post;
 use Doctrine\ORM\QueryBuilder;
 
@@ -14,7 +14,7 @@ class PostRepository extends BaseRepository
     {
         $args = array_merge([
             'title' => null,
-            'status' => PostStatus::DRAFT->value,
+            'status' => ContentStatus::DRAFT->value,
             'content' => null,
             'slug' => null,
             'featuredImageUrl' => null,
@@ -28,7 +28,7 @@ class PostRepository extends BaseRepository
             throw new \InvalidArgumentException('Content is required.');
         }
 
-        $status = PostStatus::tryFrom($args['status']);
+        $status = ContentStatus::tryFrom($args['status']);
         if ($status === null) {
             throw new \InvalidArgumentException('Invalid status.');
         }
@@ -56,7 +56,7 @@ class PostRepository extends BaseRepository
             ->select('p')
             ->from(Post::class, 'p')
             ->where('p.status = :status')
-            ->setParameter('status', PostStatus::PUBLISHED)
+            ->setParameter('status', ContentStatus::PUBLISHED)
             ->orderBy('p.publishedAt', 'DESC')
             ->getQuery()
             ->getResult();

--- a/src/Traits/HasContentStatus.php
+++ b/src/Traits/HasContentStatus.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace TheatreCMS\Traits;
+
+use Doctrine\ORM\Mapping\Column;
+use TheatreCMS\Enums\ContentStatus;
+
+/**
+ * The shared editorial status (draft/published) engine: one mapped `status`
+ * column plus its accessors, reused by every content type that needs a
+ * publication workflow instead of each entity defining its own parallel
+ * status field/enum. Currently used by Post and Page; Seasons, Productions,
+ * and Events are expected to adopt this same trait.
+ *
+ * Composing classes must set an initial status themselves (typically in
+ * their constructor) — this trait does not assume a default.
+ */
+trait HasContentStatus
+{
+    #[Column(type: 'string', length: 32, nullable: false, enumType: ContentStatus::class)]
+    private ContentStatus $status;
+
+    public function getStatus(): ContentStatus
+    {
+        return $this->status;
+    }
+
+    public function setStatus(ContentStatus $status): self
+    {
+        $this->status = $status;
+
+        return $this;
+    }
+
+    public function isPublished(): bool
+    {
+        return $this->status === ContentStatus::PUBLISHED;
+    }
+}

--- a/templates/admin/events/edit.html.twig
+++ b/templates/admin/events/edit.html.twig
@@ -27,7 +27,7 @@
                        value="{{ event.title }}"
                        placeholder="{{ event.production ? event.production.name : '' }}"
                        class="w-full rounded-md border-gray-300 shadow-sm">
-                <p class="mt-1 text-xs text-gray-500">Leave blank to default to the production name. Suggested uses might include "Opening Night", "Audio Description", "Performance Plus Post-show Discussion" etc.</p>
+                <p class="mt-1 text-xs text-gray-500">Leave blank to default to the production name. Suggested uses might include "Opening Night", "Audio Description", "Performance Plus Post-sahow Discussion" etc.</p>
             </div>
 
             <div>

--- a/templates/admin/pages/_list.html.twig
+++ b/templates/admin/pages/_list.html.twig
@@ -3,12 +3,13 @@
         <thead class="text-sm text-body bg-neutral-secondary-soft border-b border-default">
             <tr>
                 <th scope="col" class="px-6 py-3 font-medium">Title</th>
+                <th scope="col" class="px-6 py-3 font-medium">Status</th>
                 <th scope="col" class="px-6 py-3 font-medium">Last Updated</th>
                 <th scope="col" class="px-6 py-3 font-medium text-right">Actions</th>
             </tr>
         </thead>
         <tbody id="pageList">
-            {% include 'admin/pages/_table.html.twig' with {'pages': pages} %}
+            {% include 'admin/pages/_table.html.twig' with {'pages': pages, 'status_labels': statuses} %}
         </tbody>
     </table>
 

--- a/templates/admin/pages/_table.html.twig
+++ b/templates/admin/pages/_table.html.twig
@@ -4,6 +4,7 @@
             <div class="text-sm font-medium text-gray-900">{{ page.title }}</div>
             <div class="text-xs text-gray-500">Slug: <a href="/{{ page.slug }}" class="hover:underline">{{ page.slug }}</a></div>
         </td>
+        <td class="px-6 py-4">{{ status_labels[page.status.value] ?? page.status.label }}</td>
         <td class="px-6 py-4">
             {{ page.modifiedAt|date('Y-m-d H:i') }}
         </td>
@@ -15,6 +16,6 @@
     </tr>
 {% else %}
     <tr class="bg-neutral-primary border-b border-default">
-        <td class="px-6 py-4" colspan="3">No pages found.</td>
+        <td class="px-6 py-4" colspan="4">No pages found.</td>
     </tr>
 {% endfor %}

--- a/templates/admin/pages/create.html.twig
+++ b/templates/admin/pages/create.html.twig
@@ -21,6 +21,15 @@
 				<input type="text" name="title" id="title" required maxlength="255" class="w-full rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring focus:ring-blue-200">
 			</div>
 
+			<div>
+				<label for="status" class="block text-sm font-medium text-gray-700 mb-1">Status</label>
+				<select name="status" id="status" class="w-full rounded-md border-gray-300 shadow-sm">
+					{% for key, label in statuses %}
+						<option value="{{ key }}">{{ label }}</option>
+					{% endfor %}
+				</select>
+			</div>
+
 			<div class="md:col-span-2 space-y-3">
 				<label for="content" class="block text-sm font-medium text-gray-700">Content</label>
 				<div id="editorjs" class="rounded-md border border-gray-200 bg-white shadow-sm"></div>

--- a/templates/admin/pages/edit.html.twig
+++ b/templates/admin/pages/edit.html.twig
@@ -28,6 +28,15 @@
 				<input type="text" name="slug" id="slug" maxlength="255" value="{{ page.slug }}" class="w-full rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring focus:ring-blue-200">
 			</div>
 
+			<div>
+				<label for="status" class="block text-sm font-medium text-gray-700 mb-1">Status</label>
+				<select name="status" id="status" class="w-full rounded-md border-gray-300 shadow-sm">
+					{% for key, label in statuses %}
+						<option value="{{ key }}" {% if key == page.status.value %}selected{% endif %}>{{ label }}</option>
+					{% endfor %}
+				</select>
+			</div>
+
 			<div class="md:col-span-2 space-y-3">
 				<label for="content" class="block text-sm font-medium text-gray-700">Content</label>
 				<div id="editorjs" class="rounded-md border border-gray-200 bg-white shadow-sm"></div>

--- a/templates/admin/pages/index.html.twig
+++ b/templates/admin/pages/index.html.twig
@@ -13,5 +13,5 @@
         </div>
     </div>
 
-    {% include 'admin/pages/_list.html.twig' with {'pages': pages, 'pagination': pagination} %}
+    {% include 'admin/pages/_list.html.twig' with {'pages': pages, 'statuses': statuses, 'pagination': pagination} %}
 {% endblock %}

--- a/templates/layouts/admin.html.twig
+++ b/templates/layouts/admin.html.twig
@@ -33,6 +33,7 @@
 		<script src="/assets/js/editorjs/schedule.js"></script>
 		<script src="/assets/js/editorjs/gallery.js"></script>
 		<script src="/assets/js/editorjs/text-variant-tune.js"></script>
+		<link rel="stylesheet" href="/assets/css/editorjs-editor.css">
 
 		{# HTMX for progressive enhancement #}
 		<script src="https://unpkg.com/htmx.org@1.9.2"></script>

--- a/www/assets/css/editorjs-editor.css
+++ b/www/assets/css/editorjs-editor.css
@@ -1,0 +1,66 @@
+/* Base styles for the EditorJS editing surface itself (the "input"), not its
+   rendered frontend output. Tailwind's Preflight reset strips default heading
+   styles, so without this a Header block looks identical to plain paragraph
+   text while you're editing it. This is the corollary of WordPress's
+   editor-style.css: it exists purely to give WYSIWYG parity between what an
+   editor sees while typing and how the content actually reads once rendered
+   on the frontend (see the .prose rules in site.css) — loaded on every admin
+   page since EditorJS itself is (see templates/layouts/admin.html.twig).
+
+   Scoped under .codex-editor (EditorJS's own root class) so nothing here
+   leaks into the rest of the admin UI. */
+
+.codex-editor h1.ce-header {
+    margin: 1.5rem 0 0.75rem;
+    font-size: 2rem;
+    font-weight: 800;
+    line-height: 1.2;
+    color: #111827;
+}
+
+.codex-editor h2.ce-header {
+    margin: 1.5rem 0 0.75rem;
+    font-size: 1.5rem;
+    font-weight: 700;
+    line-height: 1.25;
+    color: #111827;
+}
+
+.codex-editor h3.ce-header {
+    margin: 1.25rem 0 0.5rem;
+    font-size: 1.25rem;
+    font-weight: 700;
+    line-height: 1.3;
+    color: #111827;
+}
+
+.codex-editor h4.ce-header {
+    margin: 1rem 0 0.5rem;
+    font-size: 1.125rem;
+    font-weight: 600;
+    line-height: 1.35;
+    color: #111827;
+}
+
+.codex-editor h5.ce-header,
+.codex-editor h6.ce-header {
+    margin: 1rem 0 0.5rem;
+    font-size: 1rem;
+    font-weight: 600;
+    line-height: 1.4;
+    color: #111827;
+}
+
+.codex-editor .ce-block:first-child h1.ce-header,
+.codex-editor .ce-block:first-child h2.ce-header,
+.codex-editor .ce-block:first-child h3.ce-header,
+.codex-editor .ce-block:first-child h4.ce-header,
+.codex-editor .ce-block:first-child h5.ce-header,
+.codex-editor .ce-block:first-child h6.ce-header {
+    margin-top: 0;
+}
+
+.codex-editor .ce-paragraph {
+    line-height: 1.7;
+    color: #1f2937;
+}


### PR DESCRIPTION
This pull request standardizes editorial status handling across both Posts and Pages by introducing a shared `ContentStatus` enum, replacing the previous `PostStatus` enum. It also adds a `status` field to the `pages` database table and updates all relevant models, repositories, and controllers to support draft/published workflows for pages, mirroring the posts workflow. Additionally, the UI and data handling for admin pages and posts are updated to use the new shared status system.

**Editorial Status Standardization**

* Introduced a new `ContentStatus` enum to unify status handling for content types (Posts and Pages), replacing the previous `PostStatus` enum and updating all references accordingly. (`src/Enums/ContentStatus.php` [[1]](diffhunk://#diff-895a2086f8e3c27b1bb23cb1c9972bcde7e23d41ab48af076c53f5c2b5058fc4L5-R11) `src/Controllers/PostController.php` [[2]](diffhunk://#diff-0dfdea2ebe4cd2de7960965eec5d8b3b9f1110552e5bb69c12004f56e43adb7bL11-R11) [[3]](diffhunk://#diff-0dfdea2ebe4cd2de7960965eec5d8b3b9f1110552e5bb69c12004f56e43adb7bL40-R48) [[4]](diffhunk://#diff-0dfdea2ebe4cd2de7960965eec5d8b3b9f1110552e5bb69c12004f56e43adb7bL62-R62) [[5]](diffhunk://#diff-0dfdea2ebe4cd2de7960965eec5d8b3b9f1110552e5bb69c12004f56e43adb7bL83-R84) [[6]](diffhunk://#diff-0dfdea2ebe4cd2de7960965eec5d8b3b9f1110552e5bb69c12004f56e43adb7bL139-R139) [[7]](diffhunk://#diff-0dfdea2ebe4cd2de7960965eec5d8b3b9f1110552e5bb69c12004f56e43adb7bL181-R181) [[8]](diffhunk://#diff-0dfdea2ebe4cd2de7960965eec5d8b3b9f1110552e5bb69c12004f56e43adb7bL215-R215) [[9]](diffhunk://#diff-0dfdea2ebe4cd2de7960965eec5d8b3b9f1110552e5bb69c12004f56e43adb7bL235-R235) `src/Repositories/PostRepository.php` [[10]](diffhunk://#diff-cee285fbcf3147ebfc4022e4cdf98084ca7a37959ce6f6ee091fac07f922331dL5-R5) [[11]](diffhunk://#diff-cee285fbcf3147ebfc4022e4cdf98084ca7a37959ce6f6ee091fac07f922331dL17-R17) [[12]](diffhunk://#diff-cee285fbcf3147ebfc4022e4cdf98084ca7a37959ce6f6ee091fac07f922331dL31-R31) [[13]](diffhunk://#diff-cee285fbcf3147ebfc4022e4cdf98084ca7a37959ce6f6ee091fac07f922331dL59-R59) `src/Models/Post.php` [[14]](diffhunk://#diff-9f898d821456d3dca7cf497ffb72c1c71fe749e73a058d53173990238dcf2cdfL11-L24) [[15]](diffhunk://#diff-9f898d821456d3dca7cf497ffb72c1c71fe749e73a058d53173990238dcf2cdfL40-R48) [[16]](diffhunk://#diff-9f898d821456d3dca7cf497ffb72c1c71fe749e73a058d53173990238dcf2cdfL70-L81) [[17]](diffhunk://#diff-9f898d821456d3dca7cf497ffb72c1c71fe749e73a058d53173990238dcf2cdfL139-L143)

* Added the `ContentStatus` trait to both `Page` and `Post` models to provide shared status functionality. (`src/Models/Page.php` [[1]](diffhunk://#diff-0f1abee95f3698c4e9bb7a4e57b8ff77657f9e2495994a91ccf3681251e036cfR11-R18) [[2]](diffhunk://#diff-0f1abee95f3698c4e9bb7a4e57b8ff77657f9e2495994a91ccf3681251e036cfL30-R37) `src/Models/Post.php` [[3]](diffhunk://#diff-9f898d821456d3dca7cf497ffb72c1c71fe749e73a058d53173990238dcf2cdfL11-L24)

**Pages Draft/Publish Workflow**

* Added a `status` column to the `pages` table, with a migration that backfills existing pages as 'published' and removes the DB-level default for consistency with posts. (`migrations/20260820_add_status_to_pages.sql` [migrations/20260820_add_status_to_pages.sqlR1-R8](diffhunk://#diff-bdb3ba83bcd47c663011f538aede82976c1bc056bf20710c9c27e3ac6a9ef2fdR1-R8))
* Updated the `Page` model constructor and repository to require and validate a status, and to use the new status when creating pages. (`src/Models/Page.php` [[1]](diffhunk://#diff-0f1abee95f3698c4e9bb7a4e57b8ff77657f9e2495994a91ccf3681251e036cfL30-R37) `src/Repositories/PageRepository.php` [[2]](diffhunk://#diff-7a7d26d88c7dbe18cc899984cd5a5bbedd2ef1b070b6a837c25c73d1c0e2d9c3R16) [[3]](diffhunk://#diff-7a7d26d88c7dbe18cc899984cd5a5bbedd2ef1b070b6a837c25c73d1c0e2d9c3L27-R34)

**Admin UI and Controller Updates**

* Updated `PageController` and `PostController` to pass status labels to views, accept and validate status in create/update actions, and default new content to draft status. (`src/Controllers/PageController.php` [[1]](diffhunk://#diff-7490fa8f6d9d484b4b1c9f9ae3d5de7ec8243b7176e30626234d395b8cbef497R9) [[2]](diffhunk://#diff-7490fa8f6d9d484b4b1c9f9ae3d5de7ec8243b7176e30626234d395b8cbef497L28-R43) [[3]](diffhunk://#diff-7490fa8f6d9d484b4b1c9f9ae3d5de7ec8243b7176e30626234d395b8cbef497R56) [[4]](diffhunk://#diff-7490fa8f6d9d484b4b1c9f9ae3d5de7ec8243b7176e30626234d395b8cbef497L61-R77) [[5]](diffhunk://#diff-7490fa8f6d9d484b4b1c9f9ae3d5de7ec8243b7176e30626234d395b8cbef497R103) [[6]](diffhunk://#diff-7490fa8f6d9d484b4b1c9f9ae3d5de7ec8243b7176e30626234d395b8cbef497L123-R140) [[7]](diffhunk://#diff-7490fa8f6d9d484b4b1c9f9ae3d5de7ec8243b7176e30626234d395b8cbef497R163-R174) `src/Controllers/PostController.php` [[8]](diffhunk://#diff-0dfdea2ebe4cd2de7960965eec5d8b3b9f1110552e5bb69c12004f56e43adb7bL40-R48) [[9]](diffhunk://#diff-0dfdea2ebe4cd2de7960965eec5d8b3b9f1110552e5bb69c12004f56e43adb7bL62-R62) [[10]](diffhunk://#diff-0dfdea2ebe4cd2de7960965eec5d8b3b9f1110552e5bb69c12004f56e43adb7bL83-R84) [[11]](diffhunk://#diff-0dfdea2ebe4cd2de7960965eec5d8b3b9f1110552e5bb69c12004f56e43adb7bL139-R139) [[12]](diffhunk://#diff-0dfdea2ebe4cd2de7960965eec5d8b3b9f1110552e5bb69c12004f56e43adb7bL181-R181) [[13]](diffhunk://#diff-0dfdea2ebe4cd2de7960965eec5d8b3b9f1110552e5bb69c12004f56e43adb7bL215-R215) [[14]](diffhunk://#diff-0dfdea2ebe4cd2de7960965eec5d8b3b9f1110552e5bb69c12004f56e43adb7bL235-R235)

**Frontend Routing and Visibility**

* Updated page routing to only serve published pages to the frontend, returning a 404 for drafts or non-existent pages. (`app/routes/frontend/pages.php` [app/routes/frontend/pages.phpL17-R17](diffhunk://#diff-2c8838702138d9a4511b34c82587f3f659ebe9b5b2db3cc97858a59c93c31c80L17-R17))

These changes lay the groundwork for consistent editorial workflows across content types and improve the flexibility of content publishing in the application.